### PR TITLE
Improve ISO view for generic ISO, NCEI, and Pangaea content

### DIFF
--- a/lib/style/skins/metacatui/iso19115/iso-md.xsl
+++ b/lib/style/skins/metacatui/iso19115/iso-md.xsl
@@ -188,4 +188,87 @@
         <xsl:value-of select="./*/gml:identifier/text()" />
         <xsl:value-of select="./*/gml:name/text()" />
     </xsl:template>
+    <!-- gmd:MD_Distribution 
+        - gmd:distributionFormat, 0-inf ( just grab gmd:MD_Format/gmd:name for each)
+        - gmd:distributor/gmd:MD_Distributor... hold off on this for now?
+        - gmd:transferOptions 0-inf / 
+            gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL/text()
+            and
+            gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:function/gmd:URL/gmd:CI_OnLineFunctionCode/text()
+    -->
+    <xsl:template match="gmd:MD_Distribution">
+        <table class="table table-bordered table-hover table-striped">
+            <thead>
+                <tr>
+                    <th>URL</th>
+                    <th>Format</th>
+                </tr>
+            </thead>
+            <tbody>
+                <xsl:for-each select="./gmd:distributionFormat/gmd:MD_Format/gmd:name">
+                    <tr>
+                        <!-- Here I pop back up to the gmd:MD_Distribution to grab the 
+                        linkage. I'm doing this because the format and linkage aren't 
+                        connected in ISO but I'm choosing to assume the first name pairs
+                        with the first linkage.
+                        
+                        Also note the use of position() to grab the nth URL for the
+                        nth format. -->
+                        <td>
+                            <xsl:variable name="url" select="../../../gmd:transferOptions[position()]/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL/text()" />
+                            <xsl:element name="a">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$url" />
+                                </xsl:attribute>
+                                <xsl:value-of select="$url" />
+                            </xsl:element>
+                        </td>
+                        <td><xsl:value-of select="./gco:CharacterString/text()" /></td>
+                    </tr>
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+    <xsl:template match="gmd:MD_Distributor">
+                <table class="table table-bordered table-hover table-striped">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Protocol</th>
+                    <th>Application</th>
+                    <th>Address</th>
+                </tr>
+            </thead>
+            <tbody>
+                <xsl:for-each select="./gmd:distributorTransferOptions/gmd:MD_DigitalTransferOptions">
+                    <xsl:variable name="url">
+                        <xsl:value-of select="./gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL/text()" />
+                    </xsl:variable>
+                    <tr>
+                        <td>
+                            <xsl:value-of select="./gmd:onLine/gmd:CI_OnlineResource/gmd:name/gco:CharacterString/text()" />
+                        </td>
+                        <td>
+                            <xsl:value-of select="./gmd:onLine/gmd:CI_OnlineResource/gmd:description/gco:CharacterString/text()" />
+                        </td>
+                        <td>
+                            <xsl:value-of select="./gmd:onLine/gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString/text()" />
+                        </td>
+                        <td>
+                            <xsl:value-of select="./gmd:onLine/gmd:CI_OnlineResource/gmd:applicationProfile/gco:CharacterString/text()" />
+                        </td>
+                        <td>
+                            <xsl:element name="a">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$url" />
+                                </xsl:attribute>
+                                <xsl:value-of select="$url" />
+                            </xsl:element>
+                        </td>
+                    </tr>
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
 </xsl:stylesheet>

--- a/lib/style/skins/metacatui/iso19115/iso-md.xsl
+++ b/lib/style/skins/metacatui/iso19115/iso-md.xsl
@@ -148,29 +148,35 @@
             </tbody>
         </table>
     </xsl:template>
-    <!-- Either contains sequenceIdentifier or descriptor or both -->
     <xsl:template match="gmd:MD_RangeDimension">
+        <!-- Either contains sequenceIdentifier or descriptor or both -->
+        <!-- No units -->
         <xsl:apply-templates select="./gmd:sequenceIdentifier/*/text()" />
         <xsl:apply-templates select="./gmd:descriptor/*/text()" />
     </xsl:template>
     <xsl:template match="gmd:MD_Band">
+        <!-- Has units -->
         <xsl:value-of select="./gmd:descriptor/*/text()" />
         <xsl:apply-templates select="./gmd:units" />
     </xsl:template>
     <xsl:template match="gmd:MI_Band">
+        <!--  Has units -->
         <xsl:value-of select="./gmd:descriptor/*/text()" />
         <xsl:apply-templates select="./gmd:units" />
     </xsl:template>
     <xsl:template match="gmd:units">
-        <xsl:choose>
-            <!--  Prefer gml:name over gml:identifier if gml:name is present -->
-            <xsl:when test="/*/gml:name">
-                <xsl:value-of select="./*/gml:name/text()" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:value-of select="./*/gml:identifier/text()" />
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:variable name="unit">
+            <xsl:choose>
+                <!--  Prefer gml:name over gml:identifier if gml:name is present -->
+                <xsl:when test="/*/gml:name">
+                    <xsl:value-of select="./*/gml:name/text()" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="./*/gml:identifier/text()" />
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="concat(' (', $unit, ')')" />
     </xsl:template>
     <xsl:template match="gml:BaseUnit">
     </xsl:template>

--- a/lib/style/skins/metacatui/iso19115/iso-md.xsl
+++ b/lib/style/skins/metacatui/iso19115/iso-md.xsl
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <xsl:stylesheet 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-    xmlns:gmd="http://www.isotc211.org/2005/gmd" version="1.0">
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    version="1.0">
     <xsl:template match="gmd:MD_Identifier">
         <xsl:apply-templates select="./gmd:code" />
     </xsl:template>
@@ -120,4 +123,63 @@
     </xsl:template>
     <!-- TODO: gmd:CI_PresentationFormCode-->
     <!-- TODO: gmd:CI_Series -->
+    <xsl:template name="MD_contentInfo">
+        <!-- TODO: Support more than MD_CoverageDescription and MI_CoverageDescription in this template -->
+        <xsl:param name="contentInfo" />
+        <table class="table table-bordered table-hover table-striped">
+            <thead>
+                <tr>
+                    <th>Description</th>
+                    <th>Dimension</th>
+                </tr>
+            </thead>
+            <tbody>
+                <xsl:for-each select="$contentInfo/gmd:MD_CoverageDescription | $contentInfo/gmd:MI_CoverageDescription">
+                        <tr>
+                            <td><xsl:value-of select="./gmd:attributeDescription/gco:RecordType/text()" /></td>
+                            <td>
+                                <xsl:for-each select="./gmd:dimension">
+                                    <!-- Optional, either MD_RangeDimension or MD_Band or MI_Band -->
+                                    <xsl:apply-templates />
+                                </xsl:for-each>
+                            </td>
+                        </tr>
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+    <!-- Either contains sequenceIdentifier or descriptor or both -->
+    <xsl:template match="gmd:MD_RangeDimension">
+        <xsl:apply-templates select="./gmd:sequenceIdentifier/*/text()" />
+        <xsl:apply-templates select="./gmd:descriptor/*/text()" />
+    </xsl:template>
+    <xsl:template match="gmd:MD_Band">
+        <xsl:value-of select="./gmd:descriptor/*/text()" />
+        <xsl:apply-templates select="./gmd:units" />
+    </xsl:template>
+    <xsl:template match="gmd:MI_Band">
+        <xsl:value-of select="./gmd:descriptor/*/text()" />
+        <xsl:apply-templates select="./gmd:units" />
+    </xsl:template>
+    <xsl:template match="gmd:units">
+        <xsl:choose>
+            <!--  Prefer gml:name over gml:identifier if gml:name is present -->
+            <xsl:when test="/*/gml:name">
+                <xsl:value-of select="./*/gml:name/text()" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="./*/gml:identifier/text()" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template match="gml:BaseUnit">
+    </xsl:template>
+    <xsl:template match="gml:ConventionalUnit">
+    </xsl:template>
+    <xsl:template match="gml:DerivedUnit">
+    </xsl:template>
+    <xsl:template match="gml:UnitDefinition">
+        <xsl:value-of select="./*/gml:identifier/text()" />
+        <xsl:value-of select="./*/gml:name/text()" />
+    </xsl:template>
 </xsl:stylesheet>

--- a/lib/style/skins/metacatui/iso19115/iso-md.xsl
+++ b/lib/style/skins/metacatui/iso19115/iso-md.xsl
@@ -135,15 +135,15 @@
             </thead>
             <tbody>
                 <xsl:for-each select="$contentInfo/gmd:MD_CoverageDescription | $contentInfo/gmd:MI_CoverageDescription">
-                        <tr>
-                            <td><xsl:value-of select="./gmd:attributeDescription/gco:RecordType/text()" /></td>
-                            <td>
-                                <xsl:for-each select="./gmd:dimension">
-                                    <!-- Optional, either MD_RangeDimension or MD_Band or MI_Band -->
-                                    <xsl:apply-templates />
-                                </xsl:for-each>
-                            </td>
-                        </tr>
+                    <tr>
+                        <td><xsl:value-of select="./gmd:attributeDescription/gco:RecordType/text()" /></td>
+                        <td>
+                            <xsl:for-each select="./gmd:dimension">
+                                <!-- Optional, either MD_RangeDimension or MD_Band or MI_Band -->
+                                <xsl:apply-templates />
+                            </xsl:for-each>
+                        </td>
+                    </tr>
                 </xsl:for-each>
             </tbody>
         </table>

--- a/lib/style/skins/metacatui/iso19115/iso-md.xsl
+++ b/lib/style/skins/metacatui/iso19115/iso-md.xsl
@@ -220,6 +220,7 @@
                                 <xsl:attribute name="href">
                                     <xsl:value-of select="$url" />
                                 </xsl:attribute>
+                                <xsl:attribute name="target">_blank</xsl:attribute>
                                 <xsl:value-of select="$url" />
                             </xsl:element>
                         </td>
@@ -238,6 +239,7 @@
                     <th>Protocol</th>
                     <th>Application</th>
                     <th>Address</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -263,7 +265,17 @@
                                 <xsl:attribute name="href">
                                     <xsl:value-of select="$url" />
                                 </xsl:attribute>
+                                <xsl:attribute name="target">_blank</xsl:attribute>
                                 <xsl:value-of select="$url" />
+                            </xsl:element>
+                        </td>
+                        <td>
+                            <xsl:element name="button">
+                                <xsl:attribute name="class">btn btn-small copy</xsl:attribute>
+                                <xsl:attribute name="data-clipboard-text">
+                                    <xsl:value-of select="$url" />
+                                </xsl:attribute>
+                                Copy
                             </xsl:element>
                         </td>
                     </tr>

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -216,7 +216,7 @@
             <div class="control-group entity">
                 <h4>Attributes</h4>
                 <xsl:call-template name="MD_contentInfo">
-                    <xsl:with-param name="contentInfo" select="./gmd:contentInfo">
+                    <xsl:with-param name="contentInfo" select="./gmd:contentInfo" />
                 </xsl:call-template>
             </div>
             <xsl:if test=".//gmd:metadataConstraints">

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -186,15 +186,18 @@
                         </div>
                     </div>
                 </div>
-                <!-- Data Set Contact(s) -->
-                <div class="control-group">
-                    <label class="control-label">Data Set Contacts</label>
-                    <div class="controls">
-                        <div class="controls-well">
-                            <xsl:apply-templates select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact" />
+                <!-- Data Set Contact(s) 
+                     Optional, repeatable -->
+                <xsl:if test="/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+                    <div class="control-group">
+                        <label class="control-label">Data Set Contacts</label>
+                        <div class="controls">
+                            <div class="controls-well">
+                                <xsl:apply-templates select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact" />
+                            </div>
                         </div>
                     </div>
-                </div>
+                </xsl:if>
                 <!-- Cited responsible parties-->
                 <div class="control-group">
                     <label class="control-label">Responsible Parties</label>

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -213,12 +213,14 @@
                 <xsl:apply-templates />
             </xsl:for-each>
             <!-- gmd:MD_contentInfo (atributes) table -->
-            <div class="control-group entity">
-                <h4>Attributes</h4>
-                <xsl:call-template name="MD_contentInfo">
-                    <xsl:with-param name="contentInfo" select="./gmd:contentInfo" />
-                </xsl:call-template>
-            </div>
+            <xsl:if test="./gmd:contentInfo">
+                <div class="control-group entity">
+                    <h4>Attributes</h4>
+                    <xsl:call-template name="MD_contentInfo">
+                        <xsl:with-param name="contentInfo" select="./gmd:contentInfo" />
+                    </xsl:call-template>
+                </div>
+            </xsl:if>
             <xsl:if test=".//gmd:metadataConstraints">
                 <div class="control-group entity">
                     <h4>Metadata Constraints</h4>

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -63,7 +63,7 @@
                 <!-- TODO: hierarchyLevelName 0:∞ -->
                 <!-- Alternate identifier(s) 0:∞-->
                 <!-- gmd:identifier is an optional part of the CI_Citation element -->
-                <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier">
+                <xsl:for-each select="./gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:identifier">
                     <xsl:if test="normalize-space(.//gmd:code/gco:CharacterString/text())!=''">
                         <div class="control-group">
                             <label class="control-label">Cited Identifier</label>
@@ -93,7 +93,7 @@
                 </xsl:for-each>
                 
                 <!-- Abstract 0:∞  Only shown if the abstract has content -->
-                <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract">
+                <xsl:for-each select="./gmd:identificationInfo/*/gmd:abstract">
                     <xsl:if test="normalize-space(./gco:CharacterString/text()) != ''">
                         <div class="control-group">
                             <label class="control-label">Abstract</label>
@@ -106,7 +106,7 @@
                     </xsl:if>
                 </xsl:for-each>
                 <!-- Purpose 0:∞ -->
-                <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:purpose">
+                <xsl:for-each select="./gmd:identificationInfo/*/gmd:purpose">
                     <xsl:if test="normalize-space(./gco:CharacterString/text()) != ''">
                         <div class="control-group">
                             <label class="control-label">Purpose</label>
@@ -119,7 +119,7 @@
                     </xsl:if>
                 </xsl:for-each>
                 <!-- Publication date -->
-                <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date">
+                <xsl:for-each select="./gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date">
                     <xsl:if test="./gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/text() = 'publication'">
                         <div class="control-group">
                             <label class="control-label">Publication Date</label>
@@ -180,12 +180,12 @@
                 Each <gmd:descriptiveKeywords> block should have one or more keywords in it
                 with one thesaurus. So we render keywords from the same thesaurus together.
                 -->
-                <xsl:if test="//gmd:descriptiveKeywords">
+                <xsl:if test=".//gmd:descriptiveKeywords">
                     <div class="control-group">
                         <label class="control-label">Descriptive Keywords</label>
                         <div class="controls">
                             <div class="controls-well">
-                                <xsl:for-each select="//gmd:descriptiveKeywords">
+                                <xsl:for-each select=".//gmd:descriptiveKeywords">
                                     <xsl:apply-templates />
                                 </xsl:for-each>
                             </div>
@@ -195,7 +195,7 @@
             </div>
             <div class="control-group entity">
                 <h4>People and Associated Parties</h4>
-                <!-- Metadata Contact(s) 1:inf -->
+                <!-- Metadata Contact(s) (required, 1:inf) -->
                 <div class="control-group">
                     <label class="control-label">Metadata Contacts</label>
                     <div class="controls">
@@ -206,30 +206,32 @@
                         </div>
                     </div>
                 </div>
-                <!-- Data Set Contact(s) 
-                     Optional, repeatable -->
-                <xsl:if test="/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact">
+                <!-- Data Set Contact(s) (optional, 0-inf) -->
+                <xsl:if test=".//gmd:pointOfContact">
                     <div class="control-group">
                         <label class="control-label">Data Set Contacts</label>
                         <div class="controls">
                             <div class="controls-well">
-                                <xsl:apply-templates select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact" />
+                                <xsl:apply-templates select=".//gmd:pointOfContact" />
                             </div>
                         </div>
                     </div>
                 </xsl:if>
-                <!-- Cited responsible parties-->
-                <div class="control-group">
-                    <label class="control-label">Responsible Parties</label>
-                    <div class="controls">
-                        <div class="controls-well">
-                            <xsl:apply-templates select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty" />
+
+                <!-- Cited responsible parties (optional, 0-inf) -->
+                <xsl:if test="./gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty">
+                    <div class="control-group">
+                        <label class="control-label">Responsible Parties</label>
+                        <div class="controls">
+                            <div class="controls-well">
+                                <xsl:apply-templates select="./gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty" />
+                            </div>
                         </div>
                     </div>
-                </div>
+                </xsl:if>
             </div>
             <!-- Extent (geographic, temporal, vertical) -->
-            <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent">
+            <xsl:for-each select="./gmd:identificationInfo/*/gmd:extent">
                 <xsl:apply-templates />
             </xsl:for-each>
             <!-- gmd:MD_contentInfo (atributes) table -->
@@ -241,6 +243,9 @@
                     </xsl:call-template>
                 </div>
             </xsl:if>
+
+            <!--- Constraints -->
+            <!--- Metadata Constraints -->
             <xsl:if test=".//gmd:metadataConstraints">
                 <div class="control-group entity">
                     <h4>Metadata Constraints</h4>
@@ -249,6 +254,7 @@
                     </xsl:for-each>
                 </div>
             </xsl:if>
+            <!--- Resource Constraints -->
             <xsl:if test=".//gmd:resourceConstraints">
                 <div class="control-group entity">
                     <h4>Resource Constraints</h4>
@@ -257,6 +263,7 @@
                     </xsl:for-each>
                 </div>
             </xsl:if>
+            <!--- Supplemental Information -->
             <xsl:if test=".//gmd:supplementalInformation">
                 <div class="control-group entity">
                     <h4>Supplemental Information</h4>

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -31,7 +31,7 @@
                 </xsl:if>
                 <!-- NCEI's way of doing gmd:distributionInfo -->
                 <xsl:if test="./gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorTransferOptions">
-                    <h4>Alternate Data Access</h4>
+                    <h4>Alternate Data Access <i class="icon-cloud-download"></i></h4>
                     <xsl:apply-templates select="./gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor" />
                 </xsl:if>
                 <h4>General</h4>

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -14,6 +14,26 @@
     <xsl:template match="*[local-name()='MD_Metadata'] | *[local-name()='MI_Metadata']">
         <form class="form-horizontal">
             <div class="control-group entity">
+                <!-- distributionInfo is kind tricky: You have to go pretty deep
+                     to find out if there's actually any useful information. 
+                     Here I'm making a choice to look for at least one format 
+                     with a name to check whether we should show this section at
+                     all. 
+                     
+                     Also, the distribution format isn't tied explicitly to 
+                     the transfer options so I've made a decision to assume that
+                     the first format is for the first transfer option and so on
+                     -->
+                <!-- PANGAEA's way of doing gmd:distributionInfo -->
+                <xsl:if test="./gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format/gmd:name">
+                    <h4>Distribution</h4>
+                    <xsl:apply-templates select="./gmd:distributionInfo/gmd:MD_Distribution" />
+                </xsl:if>
+                <!-- NCEI's way of doing gmd:distributionInfo -->
+                <xsl:if test="./gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorTransferOptions">
+                    <h4>Alternate Data Access</h4>
+                    <xsl:apply-templates select="./gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor" />
+                </xsl:if>
                 <h4>General</h4>
                 <!-- fileIdentifier 0:1 -->
                 <xsl:if test="./gmd:fileIdentifier and normalize-space(./gmd:fileIdentifier/text())!=''">

--- a/lib/style/skins/metacatui/iso19115/isoroot.xsl
+++ b/lib/style/skins/metacatui/iso19115/isoroot.xsl
@@ -209,6 +209,13 @@
             <xsl:for-each select="./gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent">
                 <xsl:apply-templates />
             </xsl:for-each>
+            <!-- gmd:MD_contentInfo (atributes) table -->
+            <div class="control-group entity">
+                <h4>Attributes</h4>
+                <xsl:call-template name="MD_contentInfo">
+                    <xsl:with-param name="contentInfo" select="./gmd:contentInfo">
+                </xsl:call-template>
+            </div>
             <xsl:if test=".//gmd:metadataConstraints">
                 <div class="control-group entity">
                     <h4>Metadata Constraints</h4>

--- a/lib/style/skins/metacatui/metacatui.xml
+++ b/lib/style/skins/metacatui/metacatui.xml
@@ -35,6 +35,11 @@
     <target publicid="-//W3C//HTML//EN">/style/skins/metacatui/metacatui.xsl</target>
   </doctype>
 
+  <!-- Pangaea-variant ISO 19115 metadata -->
+  <doctype publicid="http://www.isotc211.org/2005/gmd-pangaea">
+    <target publicid="-//W3C//HTML//EN">/style/skins/metacatui/metacatui.xsl</target>
+  </doctype>
+
   <doctype publicid="-//NCEAS//login//EN">
     <target publicid="-//W3C//HTML//EN">/style/skins/metacatui/metacatui-login.xsl</target>
   </doctype>


### PR DESCRIPTION
This PR contains various bug fixes some major improvements to the ISO View Service XLTs. These changes will impact any ISO19139 content and how it renders out of the View Service.

Summary:

- Moved the Alternate Data Access Table from MetacatUI to the View Service https://github.com/NCEAS/metacatui/issues/583
- Added support for how PANGAEA does Parameters (attributes) by inserting a simple table of the parameters when the metadata has `contentInfo` elements in it
- Added support for how PANGAEA does links to their data downloads (`distributionInfo`) by putting a table of links at the top of the view
- Fixed various minor issues in the XSLTs which caused headers to get shown when there was no content in the metadata for that section

@taojing2002 would you mind taking a look-through? I've hot-patched `cn-stage-ucsb-1` with these changes and done some moderate testing but always appreciate feedbacl. See https://search-stage.test.dataone.org/#view/doi:10.1594/PANGAEA.832895_20170724_1121 for an example.