### PR TITLE
The next generation of Metacat sitemaps

### DIFF
--- a/docs/user/metacat/source/sitemaps.rst
+++ b/docs/user/metacat/source/sitemaps.rst
@@ -6,10 +6,20 @@ discussed in this section - which URLs on your websites are available for
 crawling. Currently, the only way for a search engine to crawl and index 
 Metacat so that individual metadata entries are available via Web searches 
 is with a sitemap. Metacat automatically creates sitemaps for all public 
-documents in the repository. However, you must register the sitemaps with 
-the search engine before it will take effect.
+documents in the repository that meet these criteria:
+
+- Is publicly readable
+- Is metadata
+- Is the newest version in a version chain
+
+However, you must register the sitemaps with the search engine before it will 
+take effect.
 
 
+Configuration
+-------------
+
+When sitemaps are generated, 
 Creating a Sitemap
 ------------------
 
@@ -19,21 +29,21 @@ the Web on your server, and must be registered with Google before they take
 effect. For information on the sitemap protocol, please refer to the Google 
 page on using the sitemap protocol. You can view Metacat's sitemap files at:: 
 
-  <webapps_dir>/sitemaps
+  <your_web_context>/sitemaps
 
 The directory contains one or more XML files named::
 
-  metacat<X>.xml
+  sitemap<X>.xml
 
 where ``<X>`` is a number (e.g., 1 or 2) used to increment each sitemap file. 
 Because Metacat limits the number of sitemap entries in each sitemap file to 
-25,000, the servlet creates an additional sitemap file for each group of 
-25,000 entries. 
+50,000, the servlet creates an additional sitemap file for each group of 
+50,000 entries. 
 
 Verify that your sitemap files are available to the Web by browsing to::
 
-  <your_web_context>/sitemaps/metacat<X>.xml 
-  (e.g., your.server.org/metacat/sitemaps/metacat1.xml)
+  <your_web_context>/sitemaps/sitemap<X>.xml 
+  (e.g., https://example.org/metacat/sitemaps/sitemap1.xml)
 
 Registering a Sitemap
 ---------------------

--- a/docs/user/metacat/source/sitemaps.rst
+++ b/docs/user/metacat/source/sitemaps.rst
@@ -11,15 +11,41 @@ documents in the repository that meet these criteria:
 - Is publicly readable
 - Is metadata
 - Is the newest version in a version chain
+- Is not archived
 
 However, you must register the sitemaps with the search engine before it will 
 take effect.
 
-
 Configuration
 -------------
 
-When sitemaps are generated, 
+Metacat's sitemaps functionality is controlled by three properties in 
+metacat.properties.
+
+######## Sitemap section              #########################################
+# Sitemap Interval (in milliseconds) between rebuilding the sitemap
+sitemap.interval=86400000
+# Base part of the URLs for the location of the sitemap files themselves. 
+# Either full URL or absolute path. Trailing slash optional.
+sitemap.location.base=/metacatui
+# Base part of the URLs for the location entries in the sitemaps which should
+# be the base URL of the dataset landing page.
+# Either full URL or absolute path. Trailing slash optional.
+sitemap.entry.base=/metacatui/view
+
+
+- ``sitemap.interval``: Controls the interval, in milliseconds, between 
+  rebuilding the sitemap index and sitemap files.
+- ``sitemap.location.base``: Controls the URL pattern used in the 
+  ``sitemap_index.xml`` file. You can use either a full URL 
+  (e.g., ``https://example.com/some_path``) or a URL relative to your server 
+  (e.g., ``/some_path``). This is different than the ``sitemap.entry.base`` 
+  property (see directly below).
+- ``sitemap.entry.base``: Controls the URL pattern used for the entires in the
+  individual sitemap files (e.g., ``sitemap1.xml``). You can use either a full 
+  URL (e.g., ``https://example.com/some_path``) or a URL relative to your 
+  server (e.g., ``/some_path``).
+
 Creating a Sitemap
 ------------------
 
@@ -27,11 +53,15 @@ Metacat automatically generates a sitemap file for all public documents in
 the repository on a daily basis. The sitemap file(s) must be available via 
 the Web on your server, and must be registered with Google before they take 
 effect. For information on the sitemap protocol, please refer to the Google 
-page on using the sitemap protocol. You can view Metacat's sitemap files at:: 
+page on using the sitemap protocol. You can view Metacat's sitemap files at::
 
   <your_web_context>/sitemaps
 
-The directory contains one or more XML files named::
+The directory contains an index file:
+
+  sitemap_index.xml
+  
+and one or more sitemap XML files named::
 
   sitemap<X>.xml
 

--- a/lib/metacat.properties
+++ b/lib/metacat.properties
@@ -546,14 +546,16 @@ workflowScheduler.authorizationPath=/services/AuthorizationService
 workflowScheduler.authenticationPath=/services/AuthenticationService
 workflowScheduler.queryPath=/services/QueryService
 
-######## SiteMap section              #########################################
-
-# relative directory path in which sitemap files should be written
-## sitemapDirectory=@install-dir@/sitemaps
-
-# Interval (in milliseconds) between rebuilding the sitemap
+######## Sitemap section              #########################################
+# Sitemap Interval (in milliseconds) between rebuilding the sitemap
 sitemap.interval=86400000
-sitemap.excludedata=false
+# Base part of the URLs for the location of the sitemap files themselves. 
+# Either full URL or absolute path. Trailing slash optional.
+sitemap.location.base=/metacatui
+# Base part of the URLs for the location entries in the sitemaps which should
+# be the base URL of the dataset landing page.
+# Either full URL or absolute path. Trailing slash optional.
+sitemap.entry.base=/metacatui/view
 
 ######## Workflow engine section              #########################################
 executionEngine.workflowRunEngineName=localWorkflowEngine

--- a/src/edu/ucsb/nceas/metacat/MetacatHandler.java
+++ b/src/edu/ucsb/nceas/metacat/MetacatHandler.java
@@ -3946,9 +3946,37 @@ public class MetacatHandler {
             
             File directory = new File(directoryName);
             directory.mkdirs();
-            String urlRoot = request.getRequestURL().toString();
-            Sitemap smap = new Sitemap(directory, urlRoot, skin);
-            long firstDelay = 60*1000;   // 60 seconds delay
+
+            // Determine sitemap location and entry base URLs. Prepends the 
+            // secure server URL from the metacat configuration if the 
+            // values in the properties don't start with 'http' (e.g., '/view')
+            String serverUrl = "";
+            String locationBase = "";
+            String entryBase = "";
+
+            try {
+                serverUrl = SystemUtil.getSecureServerURL();
+                locationBase = PropertyService.getProperty("sitemap.location.base");
+                entryBase = PropertyService.getProperty("sitemap.entry.base");
+            } catch (PropertyNotFoundException pnfe) {
+                logMetacat.error("MetacatHandler.scheduleSitemapGeneration - " +
+                		         "Could not run site map generation because property " +
+                		         "could not be found: " + pnfe.getMessage());
+            }
+
+            // Prepend server URL to locationBase if needed
+            if (!locationBase.startsWith("http")) {
+                locationBase = serverUrl + locationBase;
+            }
+
+            // Prepend server URL to entryBase if needed
+            if (!entryBase.startsWith("http")) {
+                entryBase = serverUrl + entryBase;
+            }
+            
+            Sitemap smap = new Sitemap(directory, locationBase, entryBase);
+            long firstDelay = 10*1000;   // 60 seconds delay
+
             timer.schedule(smap, firstDelay, sitemapInterval);
             _sitemapScheduled = true;
         }

--- a/src/edu/ucsb/nceas/metacat/Sitemap.java
+++ b/src/edu/ucsb/nceas/metacat/Sitemap.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimerTask;
+import java.net.URLEncoder;
 
 import org.apache.log4j.Logger;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -244,7 +245,10 @@ public class Sitemap extends TimerTask {
                 url.append("/");
             }
 
-            url.append(StringEscapeUtils.escapeHtml(pid));
+            // URL-encode _and_ XML escape the PID.
+            url.append(StringEscapeUtils.escapeXml(
+                URLEncoder.encode(pid, "UTF-8"))
+            );
             
             sitemap.write("\t<url>\n\t\t<loc>");
             sitemap.write(url.toString());

--- a/src/edu/ucsb/nceas/metacat/Sitemap.java
+++ b/src/edu/ucsb/nceas/metacat/Sitemap.java
@@ -204,10 +204,8 @@ public class Sitemap extends TimerTask {
      */
     private void writeSitemapHeader(Writer sitemap) throws IOException {
         sitemap.write(PROLOG);
-        String header = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n" +
-                "xmlns:sm=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n" +
-                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-                "xsi:schemaLocation=\"http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\">\n";
+        String header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">";
         
         sitemap.write(header);
         sitemap.flush();

--- a/src/edu/ucsb/nceas/metacat/Sitemap.java
+++ b/src/edu/ucsb/nceas/metacat/Sitemap.java
@@ -262,9 +262,9 @@ public class Sitemap extends TimerTask {
                 URLEncoder.encode(pid, "UTF-8"))
             );
             
-            sitemap.write("\t<url>\n\t\t<loc>");
+            sitemap.write("  <url><loc>");
             sitemap.write(url.toString());
-            sitemap.write("</loc>\n\t</url>\n");
+            sitemap.write("</loc></url>\n");
             sitemap.flush();
         }
     }
@@ -346,14 +346,13 @@ public class Sitemap extends TimerTask {
                 url.append("/");
             }
             url.append(filename);
-            sitemapIndex.write("<sitemap><loc>");
+            sitemapIndex.write("  <sitemap>\n    <loc>\n      ");
             sitemapIndex.write(url.toString());
-            sitemapIndex.write("</loc>");
+            sitemapIndex.write("\n    </loc>\n");
             Date now = new Date();
             SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
-            sitemapIndex.write("<lastmod>"+ fmt.format(now) +"</lastmod>");
-            sitemapIndex.write("</sitemap>");
-            sitemapIndex.write("\n");
+            sitemapIndex.write("    <lastmod>"+ fmt.format(now) +"</lastmod>\n");
+            sitemapIndex.write("  </sitemap>\n");
             sitemapIndex.flush();
         }
     }

--- a/test/edu/ucsb/nceas/metacattest/SitemapTest.java
+++ b/test/edu/ucsb/nceas/metacattest/SitemapTest.java
@@ -105,9 +105,9 @@ public class SitemapTest extends MCTestCase {
 			FileUtil.createDirectory(directoryName);
 
 			File directory = new File(directoryName);
-			String urlRoot = "http://foo.example.com/ctx/metacat";
-			String skin = "testskin";
-			Sitemap smap = new Sitemap(directory, urlRoot, skin);
+			String locationBase = "http://foo.example.com/ctx/metacat";
+			String entryBase = "http://foo.example.com/ctx/metacat";
+			Sitemap smap = new Sitemap(directory, locationBase, entryBase);
 			smap.generateSitemaps();
 			
 			File sitemap1 = new File(directory, "metacat1.xml");

--- a/test/edu/ucsb/nceas/metacattest/SitemapTest.java
+++ b/test/edu/ucsb/nceas/metacattest/SitemapTest.java
@@ -27,6 +27,8 @@ package edu.ucsb.nceas.metacattest;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Vector;
 
 import edu.ucsb.nceas.MCTestCase;
@@ -43,7 +45,8 @@ import edu.ucsb.nceas.utilities.FileUtil;
  */
 public class SitemapTest extends MCTestCase {
 
-    private String directoryName = "/tmp/sitemaps";
+	// Temp dir for storing the sitemaps we're about to generate
+    private Path sitemapTempDir;
 
     /**
      * Initialize the Metacat environment so the test can run.
@@ -52,8 +55,10 @@ public class SitemapTest extends MCTestCase {
         super.setUp();
 
         DBConnectionPool pool = DBConnectionPool.getInstance();
-        
 		metacatConnectionNeeded = true;
+
+		sitemapTempDir = Files.createTempDirectory("sitemap");
+
 		super.setUp();
     }
 
@@ -68,7 +73,7 @@ public class SitemapTest extends MCTestCase {
 			debug("logging in as: username=" + username + " password=" + password);
 			m.login(username, password);
 
-			// insert 2.0.1 document
+			// insert 2.0.1 document w/o public read (shouldn't show up in sitemap)
 			String docid1 = generateDocumentId();
 			debug("inserting docid: " + docid1 + ".1 which has no access section");
 			testdocument = getTestEmlDoc("Doc with no access section", EML2_0_1, null,
@@ -76,6 +81,7 @@ public class SitemapTest extends MCTestCase {
 			insertDocumentId(docid1 + ".1", testdocument, SUCCESS, false);
 			readDocumentIdWhichEqualsDoc(docid1, testdocument, SUCCESS, false);
 
+			// insert 2.0.1 document w/ public read that we'll obsolete next
 			String docid2 = generateDocumentId();
 			debug("inserting docid: " + docid2 + ".1 which has public read/write section");
 			Vector<String> accessRules1 = new Vector<String>();
@@ -86,7 +92,16 @@ public class SitemapTest extends MCTestCase {
 					"Doc with public read and write", EML2_0_1,
 					null, null, null, null, accessBlock, null, null, null, null);
 			insertDocumentId(docid2 + ".1", testdocument, SUCCESS, false);
-			
+
+			// Update the previous document so we can test whether sitemaps only list 
+			// the head revision in each chain
+			debug("inserting docid: " + docid2 + ".2 which has public read/write section");
+			testdocument = getTestEmlDoc(
+					"Doc with public read and write", EML2_0_1,
+					null, null, null, null, accessBlock, null, null, null, null);
+			updateDocumentId(docid2 + ".2", testdocument, SUCCESS, false);
+
+			// Insert a 2.0.1 document w/o public read (shouldn't show up sitemap)
 			String docid3 = generateDocumentId();
 			debug("inserting docid: " + docid3 + ".1 which has which has " + username + " read/write section");
 			Vector<String> accessRules2 = new Vector<String>();
@@ -101,19 +116,21 @@ public class SitemapTest extends MCTestCase {
 			debug("logging out");
 			m.logout();
 
-			// create the directory if it does not exist
-			FileUtil.createDirectory(directoryName);
+			File directory = sitemapTempDir.toFile();
 
-			File directory = new File(directoryName);
 			String locationBase = "http://foo.example.com/ctx/metacat";
 			String entryBase = "http://foo.example.com/ctx/metacat";
 			Sitemap smap = new Sitemap(directory, locationBase, entryBase);
 			smap.generateSitemaps();
 			
-			File sitemap1 = new File(directory, "metacat1.xml");
+			File sitemap1 = new File(directory, "sitemap1.xml");
 			assertTrue(sitemap1.exists() && sitemap1.isFile());
-			
-			String doc = FileUtil.readFileToString(directoryName + FileUtil.getFS() + "metacat1.xml");
+
+
+			debug(sitemapTempDir.toString());
+
+			String doc = FileUtil.readFileToString(sitemapTempDir.toString() + "/sitemap1.xml");
+
 			debug("**** sitemap doc *** \n");
 			debug(doc);
 			assertTrue(doc.indexOf("<?xml") >= 0);
@@ -121,10 +138,18 @@ public class SitemapTest extends MCTestCase {
 			assertTrue(doc.indexOf("<url>") >= 0);
 			assertTrue(doc.indexOf("http:") >= 0);
 			
-			// only docid 2 should show up in the sitemap.
+			// docid1 and docid3 should not show up in the sitemap because they have do not have a public-read access
+			// policy
 			assertTrue(doc.indexOf(docid1) == -1);
-			assertTrue(doc.indexOf(docid2) >= 0);
 			assertTrue(doc.indexOf(docid3) == -1);
+
+			// docid2.2 should show up because it has a public-read access policy and the latest version of a chain
+			assertTrue(doc.indexOf(docid2 + ".2") >= 0);
+
+			// docid2.1 should not show up because, while it has a public-read access policy, it is obsoleted by
+			// docid2.2
+			assertTrue(doc.indexOf(docid2 + ".1") == -1);
+
 		} catch (MetacatAuthException mae) {
 			fail("Authorization failed:\n" + mae.getMessage());
 		} catch (MetacatInaccessibleException mie) {


### PR DESCRIPTION
This is a minor code change but major refactor of how sitemaps work in Metacat.

The previous implementation of sitemap was intended to work with our old usage of Metacat, which was that Metacat serves its own content. Nowadays, our deployments use MetacatUI as a front-end to Metacat so the implementation needed to change.

What did I change?

- The SQL query that fetches records to go into the sitemap:
  - Now supports all metadata formats (by querying the `xml_catalog` table)
  - No longer includes archived content
  - No longer includes obsoleted content
- The filenames for the sitemap index and sitemap files themselves has changed to `sitemap_index.xml` and `sitemap{#}.xml`, respectively, to align with the common usage I saw on the web
- Configuration of sitemaps is quite different now. Because MetacatUI is now serving the content in Metacat, the sitemap URLs need to be from MetacatUI's URL space and not Metacat's as they are now. The two properties (`sitemap.location.base` and `sitemap.entry.base`) could be simplified a bit but I think what I went with is the most obvious. I could've also used the ezid configuration to control the URL space but would rather have clear configuration parameters for the two features rather than an arcane interaction between them.
- Sitemaps are now property XML escaped and URL encoded where appropriate
- Expanded the tests a bit to provide additional regression checking. I didn't add a regression test for the `archived = FALSE` part of the SQL query because my test setup is so broken but this'd be nice to do in the future
- User docs are updated to match implementation changes
- The `sitemap.excludedata` property was removed because it didn't appear to be used anyway

Closes issue: #1263 

Specific things I'd appreciate a review on is the SQL query (both its content and its potential performance implications) and the configuration properties.

