### PR TITLE
Change the phrase from beta release to release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metacat: Data Preservation and Discovery System
 
-Version: 2.10.0 Beta Release
+Version: 2.10.0 Release
 
 Send feedback and bugs to: metacat-dev@ecoinformatics.org
                            http://github.com/NCEAS/metacat


### PR DESCRIPTION
Just remove the "beta" for 2.10.0 in the readme file.