### PR TITLE
Update EML annotation support

### DIFF
--- a/lib/style/skins/metacatui/eml-2/eml-semantics.xsl
+++ b/lib/style/skins/metacatui/eml-2/eml-semantics.xsl
@@ -39,8 +39,9 @@
 
     <xsl:template name="annotation">
         <xsl:param name="context" />
-
         <xsl:element name="div">
+            <!-- The attributes on this element are redundant with the attributes on the direct children but were kept
+            for backwards compatibility with older versions of MetacatUI. -->
             <xsl:attribute name="class">annotation</xsl:attribute>
             <xsl:attribute name="data-html">true</xsl:attribute>
             <xsl:attribute name="title"><xsl:value-of select="normalize-space(./valueURI/@label)" /></xsl:attribute>
@@ -51,15 +52,26 @@
             <xsl:attribute name="data-property-uri"><xsl:value-of select="normalize-space(./propertyURI/text())" /></xsl:attribute>
             <xsl:attribute name="data-value-label"><xsl:value-of select="normalize-space(./valueURI/@label)" /></xsl:attribute>
             <xsl:attribute name="data-value-uri"><xsl:value-of select="normalize-space(./valueURI/text())" /></xsl:attribute>
-            <div class="annotation-property"><xsl:value-of select="normalize-space(./propertyURI/@label)" /></div>
-            <div class="annotation-value"><xsl:value-of select="normalize-space(./valueURI/@label)" /></div>
-            <xsl:element name="div">
-                    <xsl:attribute name="class">annotation-findmore tooltip-this</xsl:attribute>
-                    <xsl:attribute name="data-toggle">tooltip</xsl:attribute>
-                    <xsl:attribute name="data-placement">bottom</xsl:attribute>
-                    <xsl:attribute name="title"><xsl:value-of select="concat('Click to find more datasets with measurements of ', normalize-space(./valueURI/@label), '.')" /></xsl:attribute>
-                    <div><i class="icon-long-arrow-up"></i></div>
-                </xsl:element>
+            <div class="annotation-property">
+                <xsl:attribute name="title"><xsl:value-of select="normalize-space(./propertyURI/@label)" /></xsl:attribute>
+                <xsl:attribute name="data-label"><xsl:value-of select="normalize-space(./propertyURI/@label)" /></xsl:attribute>
+                <xsl:attribute name="data-uri"><xsl:value-of select="normalize-space(./propertyURI/text())" /></xsl:attribute>
+                <xsl:attribute name="data-placement">bottom</xsl:attribute>
+                <xsl:attribute name="data-html">true</xsl:attribute>
+                <xsl:attribute name="data-content"><xsl:value-of select="concat(normalize-space(./propertyURI/@label), ' ', normalize-space(./valueURI/@label)) " /></xsl:attribute>
+                <xsl:value-of select="normalize-space(./propertyURI/@label)" />
+            </div>
+            <div class="annotation-value">
+                <xsl:attribute name="title"><xsl:value-of select="normalize-space(./valueURI/@label)" /></xsl:attribute>
+                <xsl:attribute name="data-label"><xsl:value-of select="normalize-space(./valueURI/@label)" /></xsl:attribute>
+                <xsl:attribute name="data-uri"><xsl:value-of select="normalize-space(./valueURI/text())" /></xsl:attribute>
+                <xsl:attribute name="data-placement">bottom</xsl:attribute>
+                <xsl:attribute name="data-html">true</xsl:attribute>
+                <xsl:attribute name="data-content"><xsl:value-of select="concat(normalize-space(./propertyURI/@label), ' ', normalize-space(./valueURI/@label)) " /></xsl:attribute>
+                <div class="annotation-value-text">
+                    <xsl:value-of select="normalize-space(./valueURI/@label)" />
+                </div>
+            </div>
         </xsl:element>
     </xsl:template>
 

--- a/metacat-index/src/main/resources/application-context-eml-annotation.xml
+++ b/metacat-index/src/main/resources/application-context-eml-annotation.xml
@@ -17,7 +17,7 @@
 			<list>
 				<bean class="org.dataone.cn.indexer.parser.SolrField">
 					<constructor-arg name="name" value="sem_annotation" />
-					<constructor-arg name="xpath" value="//annotation/valueURI/text()" />
+					<constructor-arg name="xpath" value="//annotation/propertyURI/text() | //annotation/valueURI/text()" />
 					<constructor-arg name="multivalue" value="true" />
 				</bean>
 			</list>

--- a/metacat-index/src/main/resources/application-context-ontology-model-service.xml
+++ b/metacat-index/src/main/resources/application-context-ontology-model-service.xml
@@ -6,7 +6,8 @@
 	<bean id="ontologyModelService" class="edu.ucsb.nceas.metacat.index.annotation.OntologyModelService">
 		<property name="fieldList">
 			<list>
-				<ref bean="eml.annotation.expansion" />
+				<ref bean="eml.annotation.property.expansion" />
+				<ref bean="eml.annotation.value.expansion" />
 			</list>
 		</property>
 
@@ -57,8 +58,8 @@
 		</constructor-arg>
 	</bean>
 
-	<bean id="eml.annotation.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
-		<constructor-arg name="name" value="sem_annotation" />
+	<bean id="eml.annotation.property.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
+		<constructor-arg name="name" value="annotation_property_uri" />
 		<constructor-arg name="query">
 			<value>
 				<![CDATA[
@@ -66,9 +67,27 @@
 				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 				PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
-				SELECT ?sem_annotation
+				SELECT ?annotation_property_uri
 				WHERE {
-						<$CONCEPT_URI> rdfs:subClassOf* ?sem_annotation .
+						<$CONCEPT_URI> rdfs:subPropertyOf* ?annotation_property_uri .
+				 	}
+				 ]]>
+			</value>
+		</constructor-arg>
+	</bean>
+
+	<bean id="eml.annotation.value.expansion" class="org.dataone.cn.indexer.annotation.SparqlField">
+		<constructor-arg name="name" value="annotation_value_uri" />
+		<constructor-arg name="query">
+			<value>
+				<![CDATA[
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+				SELECT ?annotation_value_uri
+				WHERE {
+						<$CONCEPT_URI> rdfs:subClassOf* ?annotation_value_uri .
 				 	}
 				 ]]>
 			</value>

--- a/metacat-index/src/test/java/edu/ucsb/nceas/metacat/index/annotation/EmlAnnotationSubprocessorTest.java
+++ b/metacat-index/src/test/java/edu/ucsb/nceas/metacat/index/annotation/EmlAnnotationSubprocessorTest.java
@@ -67,6 +67,11 @@ public class EmlAnnotationSubprocessorTest {
                 assertTrue(values.contains("http://purl.dataone.org/odo/ECSO_00001105"));
                 assertTrue(values.contains("http://purl.dataone.org/odo/ECSO_00000531"));
                 assertTrue(values.contains("http://purl.dataone.org/odo/ECSO_00001143"));
+                assertTrue(values.contains("http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType"));
+                assertTrue(values.contains("http://purl.obolibrary.org/obo/RO_0002352"));
+                assertTrue(values.contains("http://purl.obolibrary.org/obo/RO_0000056"));
+                assertTrue(values.contains("http://purl.obolibrary.org/obo/RO_0002328"));
+
 
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 resultSolrDoc.serialize(baos, "UTF-8");

--- a/metacat-index/src/test/java/edu/ucsb/nceas/metacat/index/annotation/OntologyModelServiceTest.java
+++ b/metacat-index/src/test/java/edu/ucsb/nceas/metacat/index/annotation/OntologyModelServiceTest.java
@@ -54,7 +54,7 @@ public class OntologyModelServiceTest {
 
         System.out.println("FOOBAR: " + service.getClass().getName());
         List<ISolrDataField> fieldList = service.getFieldList();
-        assertEquals(1, fieldList.size());
+        assertEquals(2, fieldList.size());
 
         Map<String, String> altEntries = service.getAltEntryList();
         assertEquals(16, altEntries.size());

--- a/metacat-index/src/test/resources/eml-annotation-example.xml
+++ b/metacat-index/src/test/resources/eml-annotation-example.xml
@@ -16,8 +16,12 @@
         <valueURI label="Carbon Dioxide Flux">http://purl.dataone.org/odo/ECSO_00000536</valueURI>
     </annotation>
     <annotation>
-        <propertyURI label="type">http://www.w3.org/1999/02/22-rdf-syntax-ns#type</propertyURI>
+        <propertyURI label="type">http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType</propertyURI>
         <valueURI label="Total Soil Carbon">http://purl.dataone.org/odo/ECSO_00000531</valueURI>
+    </annotation>
+    <annotation>
+      <propertyURI label="type">http://purl.obolibrary.org/obo/RO_0002352</propertyURI>
+      <valueURI label="Total Soil Carbon">http://purl.dataone.org/odo/ECSO_00000531</valueURI>
     </annotation>
     <contact>
       <references>test.user</references>


### PR DESCRIPTION
Implements https://github.com/NCEAS/metacat/issues/1517

1. Updates eml-semantics XSL to support individual popovers for the property and the value (in MetacatUI)
2. Updates the indexing code to now also include property URIs (and their super-properties) in the index
