### PR TITLE
Move EML entities to bottom of display in MetacatUI skin.

### DIFF
--- a/lib/style/skins/metacatui/eml-2/eml-dataset.xsl
+++ b/lib/style/skins/metacatui/eml-2/eml-dataset.xsl
@@ -195,17 +195,6 @@
                </xsl:for-each>
              </xsl:if>
 
-
-
-           <!-- create a second easy access table listing the data entities -->
-           <xsl:if test="dataTable|spatialRaster|spatialVector|storedProcedure|view|otherEntity">
-			<xsl:if test="$withEntityLinks='1' or $displaymodule = 'printall'">
-	             <xsl:call-template name="datasetentity"/>
-			</xsl:if>
-           </xsl:if>
-
-
-
      <h4>People and Associated Parties</h4>
 
        <!-- add in the creators -->
@@ -453,6 +442,13 @@
            </xsl:for-each>
          </xsl:if>
      </div>
+
+     <!-- create a second easy access table listing the data entities -->
+     <xsl:if test="dataTable|spatialRaster|spatialVector|storedProcedure|view|otherEntity">
+      <xsl:if test="$withEntityLinks='1' or $displaymodule = 'printall'">
+              <xsl:call-template name="datasetentity"/>
+      </xsl:if>
+     </xsl:if>
 
 
        <!-- add in the intellectiual rights info -->


### PR DESCRIPTION
Based on frequent feedback and the need to support larger datasets with many files, we need to move the EML Entity metadata to the bottom of the display so that People, Methods, Locations, etc. are not buried down the page.

I deployed the change to test.arcticdata.io so others can see  what the change looks like.

See  #1567 