### PR TITLE
Feature 1612 ant streamlining

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -811,12 +811,12 @@
         </java>
     </target>
 
-    <target name="install" depends="warNoDocs, dist-metacat-index, build-metacat-ui,deploy"
+    <target name="install-dev" depends="warNoDocs, dist-metacat-index, build-metacat-ui,deploy"
             description="* * * Install Metacat For Development. Lightweight install: does not include docs * * *">
         <echo>Dev install completed at ${NOW}</echo>
     </target>
 
-    <target name="full-install" depends="build-metacat,deploy"
+    <target name="install" depends="build-metacat,deploy"
             description="Full installation of Metacat For Development, including documentation">
         <echo>Full install completed at ${NOW}</echo>
     </target>


### PR DESCRIPTION
1. Cleaned up some old commented-out stuff > 8 years old (c76a3ba1662d0a0814410e6e634fddf85ee1efd1), and reformatted in line with google coding guidelines (65cf0a31179908f25909e2511dbda3b6966477ec - mainly tabs to spaces). Pushed these changes separately, so they didn't mess up diff for the real changes

2. Changed the `install` target so it no longer builds or installs the documentation (javadoc or admin docs), This saves time (and reduced the ant wall of text) when developing.

3. Added a new `full-install` target that does install the docs (it has exactly the same functionality as the old `install` target)