### PR TITLE
Feature 1631 startupabort

### DIFF
--- a/src/edu/ucsb/nceas/metacat/healthchecks/StartupRequirementsListener.java
+++ b/src/edu/ucsb/nceas/metacat/healthchecks/StartupRequirementsListener.java
@@ -1,0 +1,294 @@
+package edu.ucsb.nceas.metacat.healthchecks;
+
+import edu.ucsb.nceas.metacat.properties.PropertyService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.nio.charset.MalformedInputException;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * <p>
+ * CoreRequirementsListener is a ServletContextListener that is called automatically by the servlet
+ * container on startup, and used to verify that we have the essential components in place for
+ * Metacat to run successfully.
+ * </p><p>
+ * If any of the checks fail: 1. Startup is aborted (instead of allowing Metacat to limp along and
+ * malfunction), as was previously the case. 2. Clear and useful error messages and instructions are
+ * logged to (tomcat logs) 'catalina .out' and 'hostname.(date).log' files
+ * </p><p>
+ * TODO: Add more test cases - this initial implementation is minimum viable solution for
+ *  /var/metacat not being writeable when metacat-site.properties is not available.
+ *  This case should be supplemented with checks for other essential components - e.g:
+ *  - SOLR is running, right version, port is accessible (at least for k8s - see note below)
+ *  - database is running and accessible (at least for k8s - see note below)
+ *  - /var/metacat exists and is writable by the web user
+ *  - properties file exists or directory is writable
+ *  NOTE: be careful what we add here! Sometimes, we want to allow Metacat to start with
+ *  incomplete dependencies, since these are configured later through the admin interface
+ *  - e.g. database connection & solr for non-k8s deployments
+ * </p>
+ * @see javax.servlet.ServletContextListener
+ */
+@WebListener
+public class StartupRequirementsListener implements ServletContextListener {
+
+    private static final Log logMetacat = LogFactory.getLog(StartupRequirementsListener.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        //call all validation methods here. If there's an unrecoverable problem, call abort()
+
+        // Check we can load properties from, and store properties to, 'metacat.properties', and
+        // get the path to 'metacat-site.properties' for subsequent check:
+        Path sitePropsFilePath = validateDefaultProperties(sce);
+
+        // Next, check we can load properties from 'metacat-site.properties', or can create a new
+        // one if it doesn't already exist
+        validateSiteProperties(sitePropsFilePath);
+
+    }
+
+    //
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // no cleanup needed
+    }
+
+    /**
+     * Check that the default properties file is readable and writeable, without throwing any
+     * exceptions.
+     *
+     * (protected to allow test access)
+     * @param sce the ServletContextEvent passed by the container on startup
+     * @return Path object pointing to 'metacat-site.properties'. Will never be null
+     * @throws RuntimeException if any unrecoverable problems are found that should cause startup
+     *                          to be aborted
+     */
+    protected Path validateDefaultProperties(ServletContextEvent sce) throws RuntimeException {
+
+        Path defaultPropsFilePath =
+            Paths.get(sce.getServletContext().getRealPath("/WEB-INF"), "metacat.properties");
+        Properties metacatProperties = new Properties();
+        Path sitePropsFilePath = null;
+        try {
+            metacatProperties.load(Files.newBufferedReader(defaultPropsFilePath));
+            metacatProperties.store(Files.newBufferedWriter(defaultPropsFilePath), "");
+
+            sitePropsFilePath = Paths.get(
+                metacatProperties.getProperty(PropertyService.SITE_PROPERTIES_DIR_PATH_KEY),
+                PropertyService.SITE_PROPERTIES_FILENAME);
+
+        } catch (IOException e) {
+            abort(
+                "Can't read or write default metacat properties: " + defaultPropsFilePath + "\n"
+                + "Check that:\n"
+                + "  1. this path is correct, and\n"
+                + "  2. 'metacat.properties' is readable and writeable by the user running tomcat",
+                e);
+        } catch (IllegalArgumentException e) {
+            abort(
+                "'metacat.properties' file (" + defaultPropsFilePath + ") contains a malformed\n"
+                    + "Unicode escape. Check the contents of 'metacat.properties' have not been "
+                    + "corrupted, before restarting.",
+                e);
+        } catch (ClassCastException e) {
+            abort(
+                "'metacat.properties' file (" + defaultPropsFilePath + ") contains keys or\n"
+                    + "values that are not Strings. Check the contents of 'metacat.properties'\n"
+                    + "have not been corrupted, before restarting.",
+                e);
+        } catch (SecurityException e) {
+            abort(
+                "Security manager denied read or write access to 'metacat.properties'\n"
+                    + "file (" + defaultPropsFilePath + "). See javadoc for\n"
+                    + "java.nio.file.Files.newBufferedReader() and .newBufferedWriter()",
+                e);
+        }
+
+        if (sitePropsFilePath == null) {
+            abort(
+                "'metacat.properties' file (" + defaultPropsFilePath + ") does not contain\n"
+                    + "a required property: 'application.sitePropertiesDir'. Add this property,\n"
+                    + "setting the value to either:\n"
+                    + "  1. the full path for the parent directory where\n"
+                    + "     'metacat-site.properties' is located, or"
+                    + "  2. if this is a new installation, the default location\n"
+                    + "     '/var/metacat/config', if that is readable/writeable by the\n"
+                    + "     tomcat user ",
+                new NullPointerException("application.sitePropertiesDir property is null"));
+        }
+        return sitePropsFilePath;
+    }
+
+    /**
+     * Check if we can load properties from, and write properties to, 'metacat-site.properties', or
+     * can create a new one if it doesn't already exist
+     *
+     * (protected to allow test access)
+     * @param sitePropsFilePath the full path to the 'metacat-site.properties' file
+     * @throws RuntimeException if any unrecoverable problems are found that should cause startup
+     *                          to be aborted
+     */
+    protected void validateSiteProperties(@NotNull Path sitePropsFilePath)
+        throws RuntimeException {
+
+        try {
+            if (sitePropsFilePath.toFile().exists()) {
+                validateSitePropertiesFileRwAccess(sitePropsFilePath);
+            } else {
+                validateSitePropertiesPathCreatable(sitePropsFilePath);
+            }
+        } catch (SecurityException e) {
+                abort(
+                    "Security manager denied access to 'metacat-site.properties' or its parent\n"
+                        + "directories (" + sitePropsFilePath + "). See javadoc for\n"
+                        + "java.nio.file.Files.newBufferedReader() and .newBufferedWriter()",
+                    e);
+            }
+    }
+
+    /**
+     * Compose a user-friendly and informative error message, log it to 'catalina.out', and
+     * include it when throwing a RuntimeException, so it also appears in 'hostname.(date).log'
+     *
+     * @param message a clear, concise error message indicating the root cause of the problem,
+     *                along with useful instructions on how to fix the issue. Ideally, the String
+     *                should include newline characters, so it is formatted nicely on multiple
+     *                lines, to help readability. For example:
+     *          <code>
+     *          "Can't get default metacat.properties from " + metacatPropsFilePath + "\n"
+     *          + "Check that:\n"
+     *          + "  1. this path is correct, and\n"
+     *          + "  2. 'metacat.properties' is readable and writeable by the user running tomcat",
+     *          </code>
+     * @param e the root cause Exception
+     * @throws RuntimeException to abort startup as requested
+     */
+    protected void abort(String message, Exception e) throws RuntimeException {
+        String abortMsg =
+            "\n\n"
+                + "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n"
+                + "* * * * * * * *    FATAL ERROR  --  STARTUP ABORTED!    * * * * * * *\n"
+                + "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n"
+                + "\n"
+                + message
+                + "\n\n"
+                + "Exception Details: " + e.getMessage()
+                + "\n\n"
+                + "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n"
+                + "* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n"
+                + "\n\n";
+        logMetacat.fatal(abortMsg, e);
+        throw new RuntimeException(abortMsg);
+    }
+
+    /**
+     * Check if we can load properties from, and write properties to, 'metacat-site.properties'
+     *
+     * @param sitePropsFilePath the full path to the 'metacat-site.properties' file
+     * @throws RuntimeException if any unrecoverable problems are found that should cause startup
+     *                          to be aborted
+     */
+    private void validateSitePropertiesFileRwAccess(Path sitePropsFilePath)
+        throws RuntimeException {
+
+        Properties siteProperties = new Properties();
+        try {
+            siteProperties.load(Files.newBufferedReader(sitePropsFilePath));
+            siteProperties.store(Files.newBufferedWriter(sitePropsFilePath), "");
+        } catch (MalformedInputException | ClassCastException e) {
+            abort(
+                "'metacat-site.properties' file (" + sitePropsFilePath + ") contains keys or\n"
+                    + "values that are not Strings. Ensure contents of 'metacat-site.properties'\n"
+                    + "have not been corrupted, before restarting.",
+                e);
+        } catch (IOException e) {
+            abort(
+                "Can't read or write default metacat properties: " + sitePropsFilePath + "\n"
+                    + "Check that:\n"
+                    + "  1. this path is correct, and\n"
+                    + "  2. 'metacat-site.properties' is readable and writeable by the user\n"
+                    + "     running tomcat",
+                e);
+        } catch (IllegalArgumentException e) {
+            abort(
+                "'metacat-site.properties' file (" + sitePropsFilePath + ") contains a malformed\n"
+                    + "Unicode escape. Check the contents of 'metacat-site.properties' have not\n"
+                    + " been corrupted, before restarting.",
+                e);
+        } catch (SecurityException e) {
+            abort(
+                "Security manager denied read or write access to 'metacat-site.properties'\n"
+                    + "file (" + sitePropsFilePath + "). See javadoc for\n"
+                    + "Files.newBufferedReader() and Files.newBufferedWriter() (in java.nio.file)",
+                e);
+        }
+    }
+
+    /**
+     * Check if we can create a new 'metacat-site.properties' if it doesn't already exist
+     *
+     * @param sitePropsFilePath the full path to the 'metacat-site.properties' file
+     * @throws RuntimeException if any unrecoverable problems are found that should cause startup
+     *                          to be aborted
+     */
+    private void validateSitePropertiesPathCreatable(Path sitePropsFilePath)
+        throws RuntimeException {
+
+        Path sitePropsParentPath = sitePropsFilePath.getParent();
+        final String permStr = "rwxr-xr--";
+        final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(permStr);
+        FileAttribute<java.util.Set<PosixFilePermission>> fileAttributes =
+            PosixFilePermissions.asFileAttribute(permissions);
+        try {
+            Files.createDirectories(sitePropsParentPath, fileAttributes);
+
+        } catch (AccessDeniedException e) {
+            abort(
+                "Can't create site properties file parent directory at " + sitePropsParentPath
+                    + "\nBefore trying to restart tomcat, ensure any existing elements of this \n"
+                    + "path are readable and writeable by the user running tomcat. \n"
+                    + "If not, either:\n"
+                    + "  1. modify permissions/ownership for those elements (preferred), or\n"
+                    + "  2. edit the property named 'application.sitePropertiesDir' in the \n"
+                    + "     'metacat.properties' file, to point to an accessible location.", e);
+        } catch (FileSystemException e) {
+            abort("Can't create directories: " + sitePropsParentPath + "\n"
+                      + "One or more elements in that path already exist, but are *files*,\n"
+                      + "not directories! Check for existing files, and move them out of the way",
+                  e);
+        } catch (UnsupportedOperationException e) {
+            abort("Problem setting permissions to '" + permStr + "' when trying to create\n"
+                      + "directories: " + sitePropsParentPath + "\n"
+                      + "Before trying to restart tomcat, ensure any existing elements of this\n"
+                      + "path are readable and writeable by the user running tomcat.\n"
+                      + "If not, either:\n"
+                      + "  1. modify permissions/ownership for those locations (preferred), or\n"
+                      + "  2. edit the property named 'application.sitePropertiesDir' in the \n"
+                      + "     'metacat.properties' file, to point to the desired location.", e);
+        } catch (IOException e) {
+            abort("Can't create site properties file parent directory at " + sitePropsParentPath
+                      + "\nBefore trying to restart tomcat, ensure this path is readable and \n"
+                      + "writeable by the user running tomcat. If not, either:\n"
+                      + "  1. modify permissions/ownership for that location (preferred), or\n"
+                      + "  2. edit the property named 'application.sitePropertiesDir' in the \n"
+                      + "     'metacat.properties' file, to point to the desired location.", e);
+        }
+    }
+}

--- a/test/edu/ucsb/nceas/LeanTestUtils.java
+++ b/test/edu/ucsb/nceas/LeanTestUtils.java
@@ -39,7 +39,7 @@ public class LeanTestUtils {
     private static boolean printDebug = false;
     private static Properties expectedProperties;
 
-    public LeanTestUtils() {
+    static {
         printDebug = Boolean.parseBoolean(getExpectedProperties().getProperty("test.printdebug"));
         debug("LeanTestUtils: 'test.printdebug' is TRUE");
     }

--- a/test/edu/ucsb/nceas/metacat/healthchecks/StartupRequirementsListenerTest.java
+++ b/test/edu/ucsb/nceas/metacat/healthchecks/StartupRequirementsListenerTest.java
@@ -1,0 +1,280 @@
+package edu.ucsb.nceas.metacat.healthchecks;
+
+import edu.ucsb.nceas.LeanTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+
+public class StartupRequirementsListenerTest {
+
+    private Path rootPath;
+    private Path defaultPropsFilePath;
+    private Path sitePropsFilePath;
+    private ServletContextEvent servletContextEventMock;
+    private StartupRequirementsListener startupRequirementsListener;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        Path rootDirectory = this.tempFolder.getRoot().toPath();
+        assertTrue(Files.isDirectory(rootDirectory));
+        assertTrue(Files.isReadable(rootDirectory));
+        assertTrue(Files.isWritable(rootDirectory));
+        this.rootPath = Paths.get(rootDirectory.toString(), "/var");
+        LeanTestUtils.debug("using temp dir at: " + rootPath);
+
+        this.sitePropsFilePath =
+            Paths.get(rootPath.toString(), "metacat", "config", "metacat-site.properties");
+
+        assertNotNull(Files.createDirectories(rootPath));
+        this.defaultPropsFilePath =
+            Files.createFile(Paths.get(rootPath.toString(), "metacat.properties"));
+        assertTrue(Files.isRegularFile(defaultPropsFilePath));
+
+        ServletContext scMock = Mockito.mock(ServletContext.class);
+        Mockito.when(scMock.getRealPath(anyString())).thenReturn(rootPath.toString());
+
+        this.servletContextEventMock = Mockito.mock(ServletContextEvent.class);
+        Mockito.when(servletContextEventMock.getServletContext()).thenReturn(scMock);
+
+        this.startupRequirementsListener = new StartupRequirementsListener();
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void contextInitialized() {
+        startupRequirementsListener.contextInitialized(servletContextEventMock);
+    }
+
+    // validateDefaultProperties() test cases //////////////////////////////////////////////////////
+
+    @Test
+    public void validateDefaultProperties_valid() {
+
+        LeanTestUtils.debug("validateDefaultProperties_valid()");
+        try {
+            startupRequirementsListener.validateDefaultProperties(servletContextEventMock);
+
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateDefaultProperties_ro() {
+
+        LeanTestUtils.debug("validateDefaultProperties_ro()");
+        try {
+            Set<PosixFilePermission> noRwAttr = PosixFilePermissions.fromString("---------");
+            Files.setPosixFilePermissions(defaultPropsFilePath, noRwAttr);
+            assertFalse(Files.isReadable(defaultPropsFilePath));
+            assertFalse(Files.isWritable(defaultPropsFilePath));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateDefaultProperties(servletContextEventMock);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateDefaultProperties_malFormedEscape() {
+
+        LeanTestUtils.debug("validateDefaultProperties_malFormedEscape()");
+        createTestProperties_malFormedEscape(defaultPropsFilePath);
+        startupRequirementsListener.validateDefaultProperties(servletContextEventMock);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateDefaultProperties_nonStringProps() {
+
+        LeanTestUtils.debug("validateDefaultProperties_nonStringProps()");
+        createTestProperties_nonStringProps(defaultPropsFilePath);
+        startupRequirementsListener.validateDefaultProperties(servletContextEventMock);
+    }
+
+    // validateSiteProperties() test cases /////////////////////////////////////////////////////////
+
+    @Test
+    public void validateSiteProperties_notExistingValid() {
+
+        LeanTestUtils.debug("validateSiteProperties_notExistingValid()");
+        Path sitePropsDir = sitePropsFilePath.getParent();
+        assertFalse(Files.isDirectory(sitePropsDir));
+        try {
+            startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        assertTrue(Files.isDirectory(sitePropsDir));
+        assertTrue(Files.isReadable(sitePropsDir));
+        assertTrue(Files.isWritable(sitePropsDir));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_notExistingRoRoot() {
+
+        LeanTestUtils.debug("validateSiteProperties_notExistingRoRoot()");
+        try {
+            Set<PosixFilePermission> roAttr = PosixFilePermissions.fromString("r--r--r--");
+            Path dummyRootDir = Files.setPosixFilePermissions(rootPath, roAttr);
+            assertNotNull(dummyRootDir);
+            //ensure root dir exists and is RO...
+            assertTrue(Files.isDirectory(dummyRootDir));
+            assertTrue(Files.isReadable(dummyRootDir));
+            assertFalse(Files.isWritable(dummyRootDir));
+            //...and that full path does nto exist yet
+            assertFalse(Files.isDirectory(sitePropsFilePath));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_notExistingObstructingFile() {
+
+        LeanTestUtils.debug("validateSiteProperties_notExistingObstructingFile()");
+        try {
+            Path dummyRootDir = Files.createDirectories(rootPath);
+            assertNotNull(dummyRootDir);
+            //ensure root dir exists and is RO...
+            assertTrue(Files.isDirectory(dummyRootDir));
+            Path filePath =
+                Paths.get(rootPath.toString(), "metacat");
+            Path dummyProps = Files.createFile(filePath);
+            assertTrue(Files.exists(dummyProps));
+            assertTrue(Files.isRegularFile(dummyProps));
+            assertTrue(Files.isReadable(dummyProps));
+            assertTrue(Files.isWritable(dummyProps));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    @Test
+    public void validateSiteProperties_existingValid() {
+
+        LeanTestUtils.debug("validateSiteProperties_existingValid()");
+        try {
+            assertNotNull(Files.createDirectories(sitePropsFilePath.getParent()));
+            Path dummyProps = Files.createFile(sitePropsFilePath);
+            assertTrue(Files.exists(dummyProps));
+            assertTrue(Files.isRegularFile(dummyProps));
+            assertTrue(Files.isReadable(dummyProps));
+            assertTrue(Files.isWritable(dummyProps));
+            startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_existingRo() {
+
+        LeanTestUtils.debug("validateSiteProperties_existingRo()");
+        try {
+            assertNotNull(Files.createDirectories(sitePropsFilePath.getParent()));
+            FileAttribute<Set<PosixFilePermission>> roAttr =
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("r-xr-xr--"));
+            Path dummyProps = Files.createFile(sitePropsFilePath, roAttr);
+            assertTrue(Files.exists(dummyProps));
+            assertTrue(Files.isRegularFile(dummyProps));
+            assertTrue(Files.isReadable(dummyProps));
+            assertFalse(Files.isWritable(dummyProps));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_existingNoAccess() {
+
+        LeanTestUtils.debug("validateSiteProperties_existingNoAccess()");
+        try {
+            assertNotNull(Files.createDirectories(sitePropsFilePath.getParent()));
+            FileAttribute<Set<PosixFilePermission>> noAccessAttr =
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------"));
+            Path dummyProps = Files.createFile(sitePropsFilePath, noAccessAttr);
+            assertTrue(Files.exists(dummyProps));
+            assertTrue(Files.isRegularFile(dummyProps));
+            assertFalse(Files.isReadable(dummyProps));
+            assertFalse(Files.isWritable(dummyProps));
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_existingMalFormedEscape() {
+
+        LeanTestUtils.debug("validateSiteProperties_existingMalFormedEscape()");
+        createTestProperties_malFormedEscape(sitePropsFilePath);
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void validateSiteProperties_existingNonStringProps() {
+
+        LeanTestUtils.debug("validateSiteProperties_existingNonStringProps()");
+        createTestProperties_nonStringProps(sitePropsFilePath);
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    public void createTestProperties_nonStringProps(Path pathToPropsFile) {
+        try {
+            assertNotNull(Files.createDirectories(pathToPropsFile.getParent()));
+            if (!Files.exists(pathToPropsFile)) {
+                Files.createFile(pathToPropsFile);
+            }
+            assertTrue(Files.exists(pathToPropsFile));
+            byte[] randomBytes = new byte[10];
+            for (int i = 0; i < randomBytes.length; i++) {
+                randomBytes[i] = (byte) (Math.random() * 256);
+            }
+            Files.write(pathToPropsFile, randomBytes);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+        startupRequirementsListener.validateSiteProperties(sitePropsFilePath);
+    }
+
+    private void createTestProperties_malFormedEscape(Path pathToPropsFile) {
+        try {
+            assertNotNull(Files.createDirectories(pathToPropsFile.getParent()));
+            if (!Files.exists(pathToPropsFile)) {
+                Files.createFile(pathToPropsFile);
+            }
+            assertTrue(Files.exists(pathToPropsFile));
+            char[] chars = {'m', 'a', 'l', '=', '\\', 'u', '\\', 'u', '\\', 'u', '\\', 'u'};
+            Iterable<CharSequence> iterable = Collections.singletonList(new String(chars));
+            Files.write(pathToPropsFile, iterable, StandardOpenOption.APPEND);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
fix for #1631 -  Abort Metacat Startup if Misconfigured and/or Critical Resources are Inaccessible 

- Metacat startup is aborted if metacat-site.properties is not found AND /var/metacat is not writeable by the metacat user (details below).
 metacat log (typically tomcat/logs/catalina.out) and host log (tomcat/logs/hostname.(date).log) contain clear messaging about what caused the aborted startup and how to fix the problem