### PR TITLE
Bugfix 1638b fix false negative

### DIFF
--- a/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
+++ b/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
@@ -56,75 +56,76 @@ public class MetacatAdminTest {
         assertFalse(incompletePropsList.containsAll(names));
     }
 
-  /**
-   * Test the method of updateUpgradeStatus. Full list as of June 2023:
-   * <code>
-   * configutil.upgrade.status=
-   * configutil.upgrade.database.status=
-   * configutil.upgrade.java.status=
-   * configutil.upgrade.solr.status=
-   * </code>
-   * Possible status values are "success", "failure" and "in_progress".
-   * 'configutil.upgrade.status' is the overall indicator that the other statuses are all "success"
-   * so:
-   *   - If status for database, java & solr all == "success", overall status == "success"
-   *   - If status for any of database, java & solr all != "success", then overall status should be
-   *   either "failure" or "in_progress", depending which one was updated most recently
-   */
-  @Test
-  public void testUpdateUpgradeStatus() throws Exception {
+    /**
+     * Test the method of updateUpgradeStatus. Full list as of June 2023:
+     * <code>
+     *   configutil.upgrade.status=
+     *   configutil.upgrade.database.status=
+     *   configutil.upgrade.java.status=
+     *   configutil.upgrade.solr.status=
+     * </code>
+     * Possible status values are "success", "failure" and "in_progress".
+     * 'configutil.upgrade.status' is the overall indicator that the other statuses are all
+     * "success" so:
+     * - If status for database, java & solr all == "success", overall status == "success"
+     * - If status for any of database, java & solr all != "success", then overall status
+     *   should be either "failure" or "in_progress", depending on which was updated most recently
+     */
+    @Test
+    public void testUpdateUpgradeStatus() throws Exception {
 
-      // 0. ensure starting conditions: all props (db, java, solr, overall) are NOT SET (i.e. == "")
-      assertStatuses_db_java_solr_all(NOT_SET, NOT_SET, NOT_SET, NOT_SET);
-      // (STATUS SUMMARY AT THIS POINT: db="", java="", solr="", overall="")
+        // 0. ensure starting conditions: all props (db, java, solr, overall) are NOT SET (i.e.
+        // == "")
+        assertStatuses_db_java_solr_all(NOT_SET, NOT_SET, NOT_SET, NOT_SET);
+        // (STATUS SUMMARY AT THIS POINT: db="", java="", solr="", overall="")
 
-      // 1. set db to "in progress"; overall should update to "in_progress" too
-      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
+        // 1. set db to "in progress"; overall should update to "in_progress" too
+        MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
 
-      //    (STATUS SUMMARY AT THIS POINT: db=ip, java="", solr="", overall=ip)
-      assertStatuses_db_java_solr_all(
-          MetacatAdmin.IN_PROGRESS, NOT_SET, NOT_SET, MetacatAdmin.IN_PROGRESS);
-
-
-      // 2. set same one (db) to "failure"; overall should update to "failure" too
-      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.FAILURE, DO_NOT_PERSIST);
-      //    (STATUS SUMMARY AT THIS POINT: db=f, java="", solr="", overall=f)
-
-      assertStatuses_db_java_solr_all(
-          MetacatAdmin.FAILURE, NOT_SET, NOT_SET, MetacatAdmin.FAILURE);
+        //    (STATUS SUMMARY AT THIS POINT: db=ip, java="", solr="", overall=ip)
+        assertStatuses_db_java_solr_all(
+            MetacatAdmin.IN_PROGRESS, NOT_SET, NOT_SET, MetacatAdmin.IN_PROGRESS);
 
 
-      // 3. set a different one (java) to "success"; overall should stay as "failure"
-      MetacatAdmin.updateUpgradeStatus(JAVA_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+        // 2. set same one (db) to "failure"; overall should update to "failure" too
+        MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.FAILURE, DO_NOT_PERSIST);
+        //    (STATUS SUMMARY AT THIS POINT: db=f, java="", solr="", overall=f)
 
-      //    (STATUS SUMMARY AT THIS POINT: db=f, java=s, solr="", overall=f)
-      assertStatuses_db_java_solr_all(
-          MetacatAdmin.FAILURE, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
-
-
-      // 4. set a db to "success"; overall should stay as "failure"
-      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
-
-      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr="", overall=f)
-      assertStatuses_db_java_solr_all(
-          MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
+        assertStatuses_db_java_solr_all(
+            MetacatAdmin.FAILURE, NOT_SET, NOT_SET, MetacatAdmin.FAILURE);
 
 
-      // 5. set solr to "in progress"; overall should update to "in_progress" too
-      MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
+        // 3. set a different one (java) to "success"; overall should stay as "failure"
+        MetacatAdmin.updateUpgradeStatus(JAVA_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
 
-      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=ip, overall=ip)
-      assertStatuses_db_java_solr_all(MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS,
-                                      MetacatAdmin.IN_PROGRESS, MetacatAdmin.IN_PROGRESS);
+        //    (STATUS SUMMARY AT THIS POINT: db=f, java=s, solr="", overall=f)
+        assertStatuses_db_java_solr_all(
+            MetacatAdmin.FAILURE, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
 
 
-      // 6. finally, set solr to "success"; overall should update to "success" too
-      MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+        // 4. set a db to "success"; overall should stay as "failure"
+        MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
 
-      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=s, overall=s)
-      assertStatuses_db_java_solr_all(
-          MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS);
-  }
+        //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr="", overall=f)
+        assertStatuses_db_java_solr_all(
+            MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
+
+
+        // 5. set solr to "in progress"; overall should update to "in_progress" too
+        MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
+
+        //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=ip, overall=ip)
+        assertStatuses_db_java_solr_all(MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS,
+                                        MetacatAdmin.IN_PROGRESS, MetacatAdmin.IN_PROGRESS);
+
+
+        // 6. finally, set solr to "success"; overall should update to "success" too
+        MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+
+        //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=s, overall=s)
+        assertStatuses_db_java_solr_all(
+            MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS);
+    }
 
     private void assertStatuses_db_java_solr_all(
         String db, String java, String solr, String overall) {

--- a/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
+++ b/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
@@ -1,94 +1,131 @@
-/**
- *  '$RCSfile$'
- *  Copyright: 2000 Regents of the University of California and the
- *              National Center for Ecological Analysis and Synthesis
- *    Purpose: To test the MetaCatURL class by JUnit
- *    Authors: Jing Tao
- *
- *   '$Author$'
- *     '$Date$'
- * '$Revision$'
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
 package edu.ucsb.nceas.metacat.admin;
 
-import edu.ucsb.nceas.MCTestCase;
-import edu.ucsb.nceas.metacat.admin.MetacatAdmin;
+import edu.ucsb.nceas.LeanTestUtils;
 import edu.ucsb.nceas.metacat.properties.PropertyService;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import edu.ucsb.nceas.utilities.PropertyNotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * A JUnit test for testing the MetacatAdmin class
  */
-public class MetacatAdminTest extends MCTestCase {
+public class MetacatAdminTest {
+
+    private static final String DB_PROP = "configutil.upgrade.database.status";
+    private static final String JAVA_PROP = "configutil.upgrade.java.status";
+    private static final String SOLR_PROP = "configutil.upgrade.solr.status";
+    private static final String ALL_PROP = "configutil.upgrade.status";
+    private static final String NOT_SET = "";
+    private static final boolean DO_NOT_PERSIST = false;
+
+    @Before
+    public void setUp() {
+        LeanTestUtils.initializePropertyService(LeanTestUtils.PropertiesMode.UNIT_TEST);
+    }
+
+    /**
+     * A test that will fail if anyone adds more of these configutil.upgrade.* properties
+     * without adding them to the testcases here
+     */
+    @Test
+    public void ensureAllPropertiesAreTested() throws Exception {
+
+        List<String> existingPropsList = Arrays.asList(
+            DB_PROP,
+            JAVA_PROP,
+            SOLR_PROP,
+            ALL_PROP
+        );
+        Set<String> names =
+            PropertyService.getPropertiesByGroup("configutil.upgrade").keySet();
+        for (String name : names) {
+            if (!existingPropsList.contains(name)) {
+                fail("This property does not have a test associated with it: configutil.upgrade."
+                + name + ". Please add it to the testcases in MetacatAdminTest!");
+            }
+        }
+        List<String> incompletePropsList = Arrays.asList(DB_PROP, ALL_PROP);
+        assertFalse(incompletePropsList.containsAll(names));
+    }
 
   /**
-   * Constructor to build the test
-   *
-   * @param name the name of the test method
+   * Test the method of updateUpgradeStatus. Full list as of June 2023:
+   * <code>
+   * configutil.upgrade.status=
+   * configutil.upgrade.database.status=
+   * configutil.upgrade.java.status=
+   * configutil.upgrade.solr.status=
+   * </code>
+   * Possible status values are "success", "failure" and "in_progress".
+   * 'configutil.upgrade.status' is the overall indicator that the other statuses are all "success"
+   * so:
+   *   - If status for database, java & solr all == "success", overall status == "success"
+   *   - If status for any of database, java & solr all != "success", then overall status should be
+   *   either "failure" or "in_progress", depending which one was updated most recently
    */
-  public MetacatAdminTest(String name){
-    super(name);
-  }
-
-
-
-  /**
-   * Create a suite of tests to be run together
-   */
-  public static Test suite()
-  {
-    TestSuite suite = new TestSuite();
-    suite.addTest(new MetacatAdminTest("initialize"));
-    suite.addTest(new MetacatAdminTest("testUpdateUpgradeStatus"));
-    return suite;
-  }
-
-  /**
-   * Run an initial test that always passes to check that the test
-   * harness is working.
-   */
-  public void initialize() {
-    assertTrue(1 == 1);
-  }
-
-  /**
-   * Test the method of updateUpgradeStatus
-   */
+  @Test
   public void testUpdateUpgradeStatus() throws Exception {
-      boolean persist = false;
-      String status = PropertyService.getProperty("configutil.upgrade.status");
-      MetacatAdmin.updateUpgradeStatus("configutil.upgrade.database.status", MetacatAdmin.IN_PROGRESS, persist);
-      assertTrue(PropertyService.getProperty("configutil.upgrade.database.status").equals(MetacatAdmin.IN_PROGRESS));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.status").equals(MetacatAdmin.IN_PROGRESS));
-      
-      MetacatAdmin.updateUpgradeStatus("configutil.upgrade.database.status", MetacatAdmin.FAILURE, persist);
-      assertTrue(PropertyService.getProperty("configutil.upgrade.database.status").equals(MetacatAdmin.FAILURE));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.status").equals(MetacatAdmin.FAILURE));
-      
-      MetacatAdmin.updateUpgradeStatus("configutil.upgrade.java.status", MetacatAdmin.SUCCESS, persist);
-      assertTrue(PropertyService.getProperty("configutil.upgrade.java.status").equals(MetacatAdmin.SUCCESS));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.database.status").equals(MetacatAdmin.FAILURE));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.status").equals(MetacatAdmin.FAILURE));
-      
-      MetacatAdmin.updateUpgradeStatus("configutil.upgrade.database.status", MetacatAdmin.SUCCESS, persist);
-      assertTrue(PropertyService.getProperty("configutil.upgrade.java.status").equals(MetacatAdmin.SUCCESS));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.database.status").equals(MetacatAdmin.SUCCESS));
-      assertTrue(PropertyService.getProperty("configutil.upgrade.status").equals(MetacatAdmin.SUCCESS));
+
+      //ensure starting conditions: all properties (db, java, solr, overall) are NOT SET (i.e. "")
+      assertStatuses_db_java_solr_all(NOT_SET, NOT_SET, NOT_SET, NOT_SET);
+      // (STATUS SUMMARY AT THIS POINT: db="", java="", solr="", overall="")
+
+      // 1. set db to "in progress"; overall should update to "in_progress" too
+      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=ip, java="", solr="", overall=ip)
+      assertStatuses_db_java_solr_all(
+          MetacatAdmin.IN_PROGRESS, NOT_SET, NOT_SET, MetacatAdmin.IN_PROGRESS);
+
+      // 2. set same one (db) to "failure"; overall should update to "failure" too
+      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.FAILURE, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=f, java="", solr="", overall=f)
+      assertStatuses_db_java_solr_all(
+          MetacatAdmin.FAILURE, NOT_SET, NOT_SET, MetacatAdmin.FAILURE);
+
+      // 3. set a different one (java) to "success"; overall should stay as "failure"
+      MetacatAdmin.updateUpgradeStatus(JAVA_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=f, java=s, solr="", overall=f)
+      assertStatuses_db_java_solr_all(
+          MetacatAdmin.FAILURE, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
+
+      // 4. set a db to "success"; overall should stay as "failure"
+      MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr="", overall=f)
+      assertStatuses_db_java_solr_all(
+          MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
+
+      // 5. set solr to "in progress"; overall should update to "in_progress" too
+      MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=ip, overall=ip)
+      assertStatuses_db_java_solr_all(MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS,
+                                      MetacatAdmin.IN_PROGRESS, MetacatAdmin.IN_PROGRESS);
+
+      // 6. finally, set solr to "success"; overall should update to "success" too
+      MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
+      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=s, overall=s)
+      assertStatuses_db_java_solr_all(
+          MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS);
   }
+
+    private void assertStatuses_db_java_solr_all(
+        String db, String java, String solr, String overall) {
+        try {
+            assertEquals("Wrong value for " + DB_PROP, db, PropertyService.getProperty(DB_PROP));
+            assertEquals("Wrong value for " + JAVA_PROP, java, PropertyService.getProperty(JAVA_PROP));
+            assertEquals("Wrong value for " + SOLR_PROP, solr, PropertyService.getProperty(SOLR_PROP));
+            assertEquals("Wrong value for " + ALL_PROP, overall, PropertyService.getProperty(ALL_PROP));
+        } catch (PropertyNotFoundException e) {
+            fail("unexpected PropertyNotFoundException: " + e.getMessage());
+        }
+    }
 }

--- a/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
+++ b/test/edu/ucsb/nceas/metacat/admin/MetacatAdminTest.java
@@ -8,12 +8,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -76,43 +74,54 @@ public class MetacatAdminTest {
   @Test
   public void testUpdateUpgradeStatus() throws Exception {
 
-      //ensure starting conditions: all properties (db, java, solr, overall) are NOT SET (i.e. "")
+      // 0. ensure starting conditions: all props (db, java, solr, overall) are NOT SET (i.e. == "")
       assertStatuses_db_java_solr_all(NOT_SET, NOT_SET, NOT_SET, NOT_SET);
       // (STATUS SUMMARY AT THIS POINT: db="", java="", solr="", overall="")
 
       // 1. set db to "in progress"; overall should update to "in_progress" too
       MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=ip, java="", solr="", overall=ip)
+
+      //    (STATUS SUMMARY AT THIS POINT: db=ip, java="", solr="", overall=ip)
       assertStatuses_db_java_solr_all(
           MetacatAdmin.IN_PROGRESS, NOT_SET, NOT_SET, MetacatAdmin.IN_PROGRESS);
 
+
       // 2. set same one (db) to "failure"; overall should update to "failure" too
       MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.FAILURE, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=f, java="", solr="", overall=f)
+      //    (STATUS SUMMARY AT THIS POINT: db=f, java="", solr="", overall=f)
+
       assertStatuses_db_java_solr_all(
           MetacatAdmin.FAILURE, NOT_SET, NOT_SET, MetacatAdmin.FAILURE);
 
+
       // 3. set a different one (java) to "success"; overall should stay as "failure"
       MetacatAdmin.updateUpgradeStatus(JAVA_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=f, java=s, solr="", overall=f)
+
+      //    (STATUS SUMMARY AT THIS POINT: db=f, java=s, solr="", overall=f)
       assertStatuses_db_java_solr_all(
           MetacatAdmin.FAILURE, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
 
+
       // 4. set a db to "success"; overall should stay as "failure"
       MetacatAdmin.updateUpgradeStatus(DB_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr="", overall=f)
+
+      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr="", overall=f)
       assertStatuses_db_java_solr_all(
           MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, NOT_SET, MetacatAdmin.FAILURE);
 
+
       // 5. set solr to "in progress"; overall should update to "in_progress" too
       MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.IN_PROGRESS, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=ip, overall=ip)
+
+      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=ip, overall=ip)
       assertStatuses_db_java_solr_all(MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS,
                                       MetacatAdmin.IN_PROGRESS, MetacatAdmin.IN_PROGRESS);
 
+
       // 6. finally, set solr to "success"; overall should update to "success" too
       MetacatAdmin.updateUpgradeStatus(SOLR_PROP, MetacatAdmin.SUCCESS, DO_NOT_PERSIST);
-      // (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=s, overall=s)
+
+      //    (STATUS SUMMARY AT THIS POINT: db=s, java=s, solr=s, overall=s)
       assertStatuses_db_java_solr_all(
           MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS, MetacatAdmin.SUCCESS);
   }


### PR DESCRIPTION
MetacatAdminTest was previously giving false "pass" status, because:

1. it didn't account for one of the properties (`configutil.upgrade.solr.status`) when testing - this should have made it always fail, but...

2. it didn't validate starting conditions, so if the operator had ever run the admin config/updates, the test would pass because `configutil.upgrade.solr.status` would always start with the value "success", thus negating (1) and allowing the test to pass

This PR fixes the above by:
1. Adding `configutil.upgrade.solr.status` to the existing tests
2. Adding validation for the status of all the `configutil.upgrade.*` properties before the tests starts
3. Adding validation for the status of all the `configutil.upgrade.*` properties at each step
4. Adding a test that will fail if anyone adds another `configutil.upgrade.*` value to the properties file without updating the test to include it.
