### PR TITLE
Feature 1623 - helm: separating `administrator.username` & `auth.administrators` properties

### DIFF
--- a/helm/admin/secrets.yaml
+++ b/helm/admin/secrets.yaml
@@ -20,15 +20,48 @@ kind: Secret
 metadata:
   name: ${RELEASE_NAME}-secrets
 type: Opaque
-stringData:    # # # EDIT THESE VALUES # do not check into GitHub!
-  # METACAT_AUTH_ADMINISTRATORS is a single admin username or LDAP-style Distinguished Name used
-  # to log into the metacat admin pages. It is NOT a list of users (despite its name), and must
-  # not contain any colons (:)
-  METACAT_AUTH_ADMINISTRATORS: your-value-here    # account will be created if not already existing
-  METACAT_ADMINISTRATOR_PASSWORD: your-value-here # account will be created if not already existing
-  POSTGRES_PASSWORD: your-value-here              # for existing postgres account
-  POSTGRES_USER: your-value-here                  # for existing postgres account
+## @param stringData
+## stringData allows specifying write-only, non-binary secret data (eg metacat credentials) in
+## string form. The stringData field is never output when reading from the API.
+##
+## Also see the mappings in the `application.envSecretKeys` property in `metacat.properties`,
+## to determine which metacat property corresponds to each of these environment variables.
+##
+## # # #    NEVER CHECK SECRETS INTO GITHUB!   # # #
+##
+stringData:
+  ## @param METACAT_ADMINISTRATOR_PASSWORD
+  ## The password for the primary admin account that will be used to authenticate with the new
+  ## metacat instance and apply any necessary setup steps, database upgrades etc. upon first run.
+  ## NOTES:
+  ## 1. In values.yaml, the corresponding username must be set as `metacat.administrator.username`,
+  ##    and must be included in the `metacat.auth.administrators` list
+  ## 2. This account will be created if it doesn't already exist in the `passwords.xml` file on
+  ##    metacat's mounted PersistentVolume (see .Values.persistence)
+  ##
+  METACAT_ADMINISTRATOR_PASSWORD: your-value-here
+  ## @param POSTGRES_USER
+  ## the Postgres database username for the (existing) metacat user
+  ##
+  POSTGRES_USER: your-value-here
+  ## @param POSTGRES_PASSWORD
+  ## the Postgres database password for the (existing) metacat user
+  ##
+  POSTGRES_PASSWORD: your-value-here
+  ## @param METACAT_GUID_DOI_USERNAME
+  ## @param METACAT_GUID_DOI_PASSWORD
+  ## if metacat.guid.doi.enabled is set to `true` in values.yaml, then METACAT_GUID_DOI_USERNAME
+  ## and METACAT_GUID_DOI_PASSWORD must be set, in order to enable publishing of Digital Object
+  ## Identifiers (see doi.org).
+  ##
   METACAT_GUID_DOI_USERNAME: your-value-here      # can be ignored if not using DOI
   METACAT_GUID_DOI_PASSWORD: your-value-here      # can be ignored if not using DOI
+  ## @param METACAT_REPLICATION_PRIVATE_KEY_PASSWORD
+  ## if CN -> CN replication is enabled, then METACAT_GUID_DOI_USERNAME
+  ## and METACAT_GUID_DOI_PASSWORD must be set, in order to enable publishing of Digital Object
+  ## Identifiers (see doi.org).
+  ##
   METACAT_REPLICATION_PRIVATE_KEY_PASSWORD: ""    # can be ignored if not using CN -> CN replication
 data: {}
+## TODO: include pem file to be nmounted at /etc/dataone/client/certs/METACAT1.pem as defined in
+##  metacat.properties for replication.certificate.file & replication.privatekey.file

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -52,6 +52,8 @@ spec:
           env:
             - name: METACAT_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: METACAT_ADMINISTRATOR_USERNAME
+              value: {{ index .Values.metacat "administrator.username" }}
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-secrets

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,6 +6,12 @@
 ## in this section comprise the minimum set of values needed to run the app and the test suite on
 ## a development machine.
 ##
+## NOTE that certain credentials must also be provided, via Kubernetes Secrets, in order for
+## metacat to function correctly. These credentials are listed in ./admin/secrets.yaml, in the
+## form of environment variables expected by metacat at runtime. Also see the mappings in the
+## `application.envSecretKeys` property in `metacat.properties`, to determine which metacat
+## property corresponds to each of these environment variables
+##
 metacat:
   ## @param metacat.application.context
   ## the application context to use - for example, if your application is hosted at
@@ -13,13 +19,31 @@ metacat:
   ## application will be https://mydomain.org/metacat/
   ##
   application.context: metacat
+  ## @param auth.admin.setupUsername
+  ## The primary admin username that will be used to authenticate with the new metacat instance
+  ## and apply any necessary setup steps, database upgrades etc. upon first run.
+  ## NOTES:
+  ## 1. The corresponding password must be set as a Secret (see ./admin/secrets.yaml), with the
+  ##    key METACAT_ADMINISTRATOR_PASSWORD
+  ## 2. This account will be created if it doesn't already exist in the `passwords.xml` file on
+  ##    metacat's mounted PersistentVolume (see .Values.persistence)
+  ## 3. This username MUST appear on the list of authorized administrators, otherwise
+  ##    container startup will fail (see @param auth.administrators)
+  ##
+  administrator.username: admin@localhost
+  ## METACAT_AUTH_ADMINISTRATORS is a colon-separated list of admin usernames or LDAP-style
+  ## Distinguished Names denoting the users who may log into metacat with administrator
+  ## privileges.
+  ##
+  auth.administrators: admin@localhost:uid=jones,o=NCEAS,dc=ecoinformatics,dc=org
   ## @param database.connectionURI
   ## connection URI for the postgres database, in the form: jdbc:postgresql://hostname/database-name
   ## host.docker.internal is equivalent to "localhost"
   ##
   database.connectionURI: jdbc:postgresql://host.docker.internal/metacat
   ## Allow users to publish Digital Object Identifiers for the data in this metacat instance?
-  ## (see doi.org). If true, you will also need to define guid.doi.username $ guid.doi.password, 
+  ## (see doi.org).
+  ## If true, you will also need to define guid.doi.username $ guid.doi.password (see secrets.yaml)
   ## and either override or use the defaults in metacat.properties for all the entries that begin
   ## with: "guid.doi."
   ##
@@ -128,9 +152,9 @@ persistence:
   enabled: true
   ## @param persistence.storageClass Storage class of backing PVC
   ##
-  ## If <storageClass> is defined -- storageClassName: <storageClass>
+  ## If <storageClass> is defined,  storageClassName: <storageClass>
   ##
-  ## If <storageClass> set to "-"  -- storageClassName: "" -- which disables dynamic PV provisioning
+  ## If <storageClass> set to "-",  storageClassName: ""  -- which disables dynamic PV provisioning
   ##   (meaning claim can only be bound to an existing PV, not a dynamically-provisioned one) with
   ##   no class (no annotation, or one set equal to "")
   ##
@@ -139,7 +163,7 @@ persistence:
   ## Instead, inspect your cluster to see what stoprageClass is set as default:
   ##    $  kubectl get storageclass
   ## ...and then explicitly set storageClass to match the name of the default storageclass
-  ## (e.g. for Rancher Desktop -- storageclass: local-path
+  ## (e.g. for Rancher Desktop, use:   storageclass: local-path)
   ##
   storageClass: local-path
   ## @param persistence.existingClaim

--- a/lib/metacat.properties
+++ b/lib/metacat.properties
@@ -57,7 +57,6 @@ application.readOnlyMode=false
 #  org.dataone.configuration.Settings
 #
 application.envSecretKeys=\
-  auth.administrators=METACAT_AUTH_ADMINISTRATORS   \
   :database.user=POSTGRES_USER                      \
   :database.password=POSTGRES_PASSWORD              \
   :guid.doi.username=METACAT_GUID_DOI_USERNAME      \

--- a/lib/metacat.properties
+++ b/lib/metacat.properties
@@ -57,7 +57,7 @@ application.readOnlyMode=false
 #  org.dataone.configuration.Settings
 #
 application.envSecretKeys=\
-  :database.user=POSTGRES_USER                      \
+   database.user=POSTGRES_USER                      \
   :database.password=POSTGRES_PASSWORD              \
   :guid.doi.username=METACAT_GUID_DOI_USERNAME      \
   :guid.doi.password=METACAT_GUID_DOI_PASSWORD      \


### PR DESCRIPTION
related to Issue #1623 

I originally conflated the admin username (used for DB upgrades at launch) with the `auth.administrators` property, when cleaning up the dockerfile and entrypoint script (i.e. I cleaned it up just a little too much :-) This meant that we could no longer provide a colon-delimited list of allowed admins for `auth.administrators`.

This PR undoes that, so now we have:

In `values.yaml:

* `administrator.username` and
* `auth.administrators`

as separate values, and edits to `statefulset.yaml`, `secrets.yaml` and `metacat.properties` to support these changes

Finally, I found a bug resulting from the recent change to the docker base image (`tomcat:8.5.90-jre8-temurin-jammy`) - this necessitated an upgrade to python 3, which broke the password hashing in `docker-entrypoint.sh`, so that's been fixed too.

