### PR TITLE
Assorted fixes based on Matt's Feedback

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,10 @@ FROM tomcat:8.5.90-jre8-temurin-jammy
 # TODO: update to tomcat:9.0.76-jre8-temurin-jammy
 
 # ARG default values that can be overridden at build-time
-ARG TAG=2.19.0
+ARG DISTBIN=2.19.0
 ARG DEVTOOLS=''
 
 # ENV default key=value env vars shared with container at runtime
-ENV METACAT_APP_CONTEXT=metacat
 ENV TC_HOME=/usr/local/tomcat
 ENV USRBINDIR=/usr/local/bin
 ENV PATH=${USRBINDIR}:$PATH
@@ -24,14 +23,13 @@ ENV DEVTOOLS=${DEVTOOLS}
 RUN useradd metacat
 
 ## ADD auto-inflates the .tar.gz
-ADD metacat-bin-${TAG}.tar.gz /tmp
+ADD "$DISTBIN" /tmp
 
-RUN apt-get update && apt-get install -y --no-install-recommends netcat python3-bcrypt unzip   && \
-    bash -c "if [[ \"$DEVTOOLS\" == \"true\" ]]; then echo '* * INSECURE! DEV TOOLS BUILD * *' && \
-        apt-get install -y --no-install-recommends vim procps lsof telnet; fi"        && \
+RUN apt-get update && apt-get install -y --no-install-recommends                         \
+        lsof netcat procps python3-bcrypt telnet unzip vim                            && \
     rm -rf /var/lib/apt/lists/*                                                       && \
-    cp /tmp/metacat.war /tmp/metacat-index.war /tmp/metacatui.war ${TC_HOME}/webapps  && \
-    chown -R metacat ${TC_HOME}/webapps                                               && \
+    mv /tmp/metacat.war /tmp/metacat-index.war /tmp/metacatui.war ${TC_HOME}/webapps  && \
+    chown -R metacat ${TC_HOME}                                                       && \
     # Tomcat Mods - TODO MB - remove after Tomcat9 upgrade
     cp  ${TC_HOME}/conf/server.xml  ${TC_HOME}/conf/server.xml.original               && \
     sed -i 's/port="8080"/relaxedPathChars="\[\]\|" \
@@ -44,9 +42,10 @@ COPY --chown=metacat docker-entrypoint.sh ${USRBINDIR}/
 #Run Container as 'metacat'
 USER metacat
 
+#Set working directory to tomcat's bin dir, to match legacy metacat relative paths
+WORKDIR "$TC_HOME"/bin
+
 EXPOSE 8080
-EXPOSE 8009
-EXPOSE 8443
 EXPOSE 5701
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,40 +2,64 @@
 
 set -e
 TAG=$1
-DEFAULT_TAG="2.19.0"
+DEFAULT_TAG="DEVELOP"
+DEFAULT_VERSION="2.19.0"
 
-if [ -z "$1" ] || [[ "$1" == "-devtools" ]]; then
-    TAG=${DEFAULT_TAG}
-    echo
-    echo "Usage: ${0} [tag] [-devtools]"
-    echo " or:   ${0}       [-devtools]    (omitting tag defaults it to ${DEFAULT_TAG})"
-    echo
-    echo "where:  tag       is typically set to the metacat version #. Setting to default: ${TAG}"
-    echo "       -devtools  is FOR DEV/DEBUGGING ONLY - NOT FOR PRODUCTION USE! Installs dev tools:"
-    echo "                    vim, procps, lsof, and telnet in the container (see Dockerfile for"
-    echo "                    complete list), thus REDUCING ITS SECURITY!"
-    echo
-fi
-
-DEVTOOLS="false"
-DEVBUILDOPTS=""
-if [[ "$1" == "-devtools" ]] || [[ "$2" == "-devtools" ]]; then
-    DEVTOOLS="true"
-    DEVBUILDOPTS="--no-cache --progress=plain"
-fi
-echo "Building with \"DEVTOOLS\" set to: ${DEVTOOLS}"
+echo
+echo "Usage:   $0 [tag] [-devtools]"
+echo "   or:   $0       [-devtools]"
+echo
+echo "where:  tag       is the image tag, which is typically the metacat version being released."
+echo "                  If this is not a release build, then omitting [tag] results in the image"
+echo "                  tag defaulting to $DEFAULT_TAG, and the container build defaulting to"
+echo "                  Metacat version $DEFAULT_VERSION."
+echo "       -devtools  is FOR DEV/DEBUGGING ONLY - NOT FOR PRODUCTION USE!"
+echo "                  *** Note that: ***"
+echo "                  -devtools mode does NOT start tomcat/metacat, but instead starts a bash"
+echo "                   infinite loop to keep the container running, for debugging purposes."
+echo "                  Consequently, you need to COMMENT OUT livenessProbe and readinessProbe in"
+echo "                   values.yaml, otherwise k8s WILL KEEP TRYING TO RESTART THE CONTAINER!"
+echo "                  -devtools installs additional command-line tools in the container (see"
+echo "                   Dockerfile for complete list), thus REDUCING ITS SECURITY!"
+echo "                  -devtools overrides the METACAT_DEBUG environment variable, setting it to"
+echo "                   'true', which enables debug output during container startup, and sets"
+echo "                   the Log4J rootLogger.level to 'DEBUG' -- THUS EXPOSING SENSITIVE INFO!!"
 echo
 
-RELEASE="metacat-bin-${TAG}.tar.gz"
+if [ -z "$1" ] || [[ "$1" == "-devtools" ]]; then
+    TAG=$DEFAULT_TAG
+    MC_VERSION=$DEFAULT_VERSION
+    echo "* * * * * *  Setting image tag to $TAG and the Metacat release version to $MC_VERSION"
+
+elif [[ -n "$1" ]]; then
+    TAG="$1"
+    MC_VERSION="$TAG"
+    echo "* * * * * *  Setting both the image tag and the Metacat release version to ${TAG})"
+fi
+echo "* * * * * *      (Remember to set 'image.tag' in values.yaml to match tag: $TAG!!)"
+
+DEVTOOLS="false"
+DEV_BUILD_OPTS=""
+if [[ "$1" == "-devtools" ]] || [[ "$2" == "-devtools" ]]; then
+    DEVTOOLS="true"
+    DEV_BUILD_OPTS="--no-cache --progress=plain"
+    echo "* * * * * *  Setting build flags to: ${DEV_BUILD_OPTS}"
+    echo "* * * * * *      (Remember to disable the livenessProbe in values.yaml, otherwise the"
+    echo "* * * * * *       pod will keep restarting!!)"
+fi
+echo "* * * * * *  Building with \"DEVTOOLS\" set to: ${DEVTOOLS}"
+echo
+
+DISTBIN="metacat-bin-${MC_VERSION}.tar.gz"
 
 # Grab the Metacat release
-if [ ! -f "../${RELEASE}" ]; then
-    echo "Could not find ../${RELEASE}"
+if [ ! -f "../${DISTBIN}" ]; then
+    echo "Could not find ../${DISTBIN}"
     echo "You must first build the metacat release with 'ant distbin'. Exiting..."
     exit 1
 fi
 
-cp ../"${RELEASE}" .
+cp ../"${DISTBIN}" .
 
-docker image build \
-    $DEVBUILDOPTS --tag metacat:"$TAG" --build-arg TAG="$TAG" --build-arg DEVTOOLS="$DEVTOOLS" .
+docker image build $DEV_BUILD_OPTS \
+    --tag metacat:"$TAG" --build-arg DISTBIN="$DISTBIN" --build-arg DEVTOOLS="$DEVTOOLS" .

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -59,6 +59,8 @@ spec:
             - name: METACAT_EXTERNAL_PORT
               {{- $metacatHttpPort := index .Values.metacat "server.httpPort" }}
               value: {{ ternary "80" $metacatHttpPort ( .Values.ingress.enabled ) | quote }}
+            - name: METACAT_APP_CONTEXT
+              value: {{ index .Values.metacat "application.context" }}
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-secrets

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,4 @@
-## Default values for metacat.
+../helm/values.yaml## Default values for metacat.
 ## This is a YAML-formatted file.
 ##
 global:
@@ -74,7 +74,8 @@ image:
   repository: metacat
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "DEVELOP"
+#  tag: ""
   ## @param image.debug Specify if debug values should be set
   ## Set to true if you would like to see extra information in metacat/tomcat logs.
   ## (Sets the Log4J rootLogger level to "DEBUG")
@@ -108,13 +109,13 @@ securityContext: {}
   #   drop:
   #   - ALL
 
-livenessProbe:
+livenessProbe:        # if this fails, pod will be killed and restarted
   httpGet:
     path: /metacat/
     port: metacat-web
-readinessProbe:
+readinessProbe:       # if this fails, pod will not be killed, but traffic won't be sent to it
   httpGet:
-    path: /metacat/  # d1/mn/v2/query/solr/q=id:*
+    path: /metacat/   # d1/mn/v2/query/solr/q=id:*
     port: metacat-web
 
 service:
@@ -155,15 +156,9 @@ ingress:
       paths:  ## TODO
         - path: "/metacat"
           pathType: Prefix
-        - path: "/metacat/admin"
-          pathType: Prefix
-        - path: "/metacat/d1"
-          pathType: Prefix
         # uncomment the following if you want metacatui to be exposed (default knb skin), and
         # access via /metacatui/  (note we need "/" exposed for access to the config.js file)
-#        - path: "/metacatui"
-#          pathType: Prefix
-        - path: "/"
+        - path: "/metacatui"
           pathType: Prefix
 ## example
 #  annotations:


### PR DESCRIPTION
Related to Issue #1623 

- separated TAG from DISTBIN version & introduced default DEVELOP image tag
- added vim, lsof, procps & telnet to default cmd line tools 
- set working dir to fix broken log4j ../logs path (fixes stacktrace in logs)
- only loop in devtools mode: don't start metacat
- edit metacatui config in place to default to knb theme 
- make script fail if admin login unsuccessful
- make log tail start from line 0
- change ingress to non-root values only (/metacat and /metacatui)
- set app context env variable from values.yaml/statefulset.yaml, instead of in docker build