### PR TITLE
Feature 1623 auth admin testfix

### DIFF
--- a/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
+++ b/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
@@ -187,7 +187,6 @@ public class PropertiesWrapperTest {
 
             // These should be a subset of 'application.envSecretKeys' in metacat.properties
             final String[] secretEnvVarKeysList = {
-                "METACAT_AUTH_ADMINISTRATORS",
                 "POSTGRES_USER",
                 "POSTGRES_PASSWORD",
                 "METACAT_GUID_DOI_PASSWORD",
@@ -196,7 +195,6 @@ public class PropertiesWrapperTest {
             };
             // These should be a subset of 'application.envSecretKeys' in metacat.properties
             final String[] secretPropsKeysList = {
-                "auth.administrators",
                 "database.user",
                 "database.password",
                 "guid.doi.password",


### PR DESCRIPTION
fixing PropertiesWrapperTest - I didn't update it when I removed the env var mapping for auth.administrators=METACAT_AUTH_ADMINISTRATORS in PR #1645 :-(