### PR TITLE
Feature 1665 proxy header secret

### DIFF
--- a/lib/log4j2.properties
+++ b/lib/log4j2.properties
@@ -54,7 +54,7 @@ appender.replicationAppender.strategy.max=100
 ##################################
 # the root logger configuration  #
 ##################################
-rootLogger.level=DEBUG
+rootLogger.level=ERROR
 rootLogger.appenderRef.console.ref=consoleAppender
 
 ################################################################################

--- a/lib/log4j2.properties
+++ b/lib/log4j2.properties
@@ -54,7 +54,7 @@ appender.replicationAppender.strategy.max=100
 ##################################
 # the root logger configuration  #
 ##################################
-rootLogger.level=ERROR
+rootLogger.level=DEBUG
 rootLogger.appenderRef.console.ref=consoleAppender
 
 ################################################################################
@@ -71,3 +71,11 @@ logger.replication.name=ReplicationLogging
 logger.replication.level=ERROR
 logger.replication.additivity=false
 logger.replication.appenderRef.rolling.ref=replicationAppender
+
+################################################################################
+# a customized logger for the package:                                         #
+#   org.apache.http.impl.conn.PoolingHttpClientConnectionManager               #
+################################################################################
+logger.poolingHttpClientConnectionManager.name=org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+logger.poolingHttpClientConnectionManager.level=ERROR
+logger.poolingHttpClientConnectionManager.appenderRef.console.ref=consoleAppender

--- a/lib/metacat.properties
+++ b/lib/metacat.properties
@@ -60,7 +60,8 @@ application.envSecretKeys=\
      database.user=POSTGRES_USER                      \
     :database.password=POSTGRES_PASSWORD              \
     :guid.doi.password=METACAT_GUID_DOI_PASSWORD      \
-    :replication.privatekey.password=METACAT_REPLICATION_PRIVATE_KEY_PASSWORD
+    :replication.privatekey.password=METACAT_REPLICATION_PRIVATE_KEY_PASSWORD \
+    :dataone.certificate.fromHttpHeader.proxyKey=METACAT_DATAONE_CERT_FROM_HTTP_HEADER_PROXY_KEY
 
 
 application.deployDir=

--- a/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
+++ b/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 @RunWith(Suite.class)
 // Add new inner classes for tests grouped by functionality, to help with clarity, and so we
-// don't have to share @Before setup code where it's not needed. Each new inner classname should
+// don't have to share @Before setup code where it's not needed. Each new inner class name should
 // be added the @Suite.SuiteClasses test suite definition, below
 @Suite.SuiteClasses({
     PropertiesWrapperTest.EnvironmentVariablesTestSuite.class,
@@ -174,7 +174,7 @@ public class PropertiesWrapperTest {
     }
 
     /**
-     * Tests that exercise the ability to override secret credential properties by settign the
+     * Tests that exercise the ability to override secret credential properties by setting the
      * values as environment variables
      */
     public static class EnvironmentVariablesTestSuite {
@@ -190,15 +190,16 @@ public class PropertiesWrapperTest {
                 "POSTGRES_USER",
                 "POSTGRES_PASSWORD",
                 "METACAT_GUID_DOI_PASSWORD",
-                "METACAT_REPLICATION_PRIVATE_KEY_PASSWORD"
-
+                "METACAT_REPLICATION_PRIVATE_KEY_PASSWORD",
+                "METACAT_DATAONE_CERT_FROM_HTTP_HEADER_PROXY_KEY"
             };
             // These should be a subset of 'application.envSecretKeys' in metacat.properties
             final String[] secretPropsKeysList = {
                 "database.user",
                 "database.password",
                 "guid.doi.password",
-                "replication.privatekey.password"
+                "replication.privatekey.password",
+                "dataone.certificate.fromHttpHeader.proxyKey"
             };
             assertEquals(secretEnvVarKeysList.length, secretPropsKeysList.length);
 


### PR DESCRIPTION
added a new ENV VAR secret mapping for use in the X-Proxy-Key header

Also suppressing some debug logging from `org.apache.http.impl.conn.PoolingHttpClientConnectionManager`