### PR TITLE
Feature 1665 hzloggingfix

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -72,13 +72,15 @@ elif [[ $1 = "catalina.sh" ]]; then
     apply_context.py "$METACAT_DIR"/WEB-INF/web.xml metacat "${METACAT_APP_CONTEXT}"
 
     # Make sure all default directories are available
-    mkdir -p /var/metacat/data \
+    mkdir -p \
+        /var/metacat/.metacat    \
+        /var/metacat/config      \
+        /var/metacat/data        \
+        /var/metacat/documents   \
         /var/metacat/inline-data \
-        /var/metacat/documents \
-        /var/metacat/temporary \
-        /var/metacat/logs \
-        /var/metacat/config \
-        /var/metacat/.metacat
+        /var/metacat/logs        \
+        /var/metacat/solr-home-legacy \
+        /var/metacat/temporary
 
     # if METACAT_DEBUG, set the root log level to "DEBUG"
     if [[ $METACAT_DEBUG == "true" ]]; then

--- a/helm/config/metacat-site.properties
+++ b/helm/config/metacat-site.properties
@@ -45,6 +45,9 @@ application.backupDir=/var/metacat/.metacat
 application.deployDir=/usr/local/tomcat/webapps
 server.internalPort=8080
 
+# Need to override this because HazelcastIndexEventLog tries to write a file here.
+solr.homeDir=/var/metacat/solr-home-legacy
+
 # Pretend the config is all done.
 # TODO - handle this more elegantly? See: https://github.com/NCEAS/metacat/issues/1638
 #

--- a/lib/log4j2.properties
+++ b/lib/log4j2.properties
@@ -54,7 +54,7 @@ appender.replicationAppender.strategy.max=100
 ##################################
 # the root logger configuration  #
 ##################################
-rootLogger.level=DEBUG
+rootLogger.level=ERROR
 rootLogger.appenderRef.console.ref=consoleAppender
 
 ################################################################################

--- a/lib/log4j2.properties
+++ b/lib/log4j2.properties
@@ -54,7 +54,7 @@ appender.replicationAppender.strategy.max=100
 ##################################
 # the root logger configuration  #
 ##################################
-rootLogger.level=ERROR
+rootLogger.level=DEBUG
 rootLogger.appenderRef.console.ref=consoleAppender
 
 ################################################################################
@@ -71,3 +71,11 @@ logger.replication.name=ReplicationLogging
 logger.replication.level=ERROR
 logger.replication.additivity=false
 logger.replication.appenderRef.rolling.ref=replicationAppender
+
+################################################################################
+# a customized logger for the package:                                         #
+#   org.apache.http.impl.conn.PoolingHttpClientConnectionManager               #
+################################################################################
+logger.poolingHttpClientConnectionManager.name=org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+logger.poolingHttpClientConnectionManager.level=ERROR
+logger.poolingHttpClientConnectionManager.appenderRef.console.ref=consoleAppender

--- a/lib/metacat.properties
+++ b/lib/metacat.properties
@@ -60,7 +60,8 @@ application.envSecretKeys=\
      database.user=POSTGRES_USER                      \
     :database.password=POSTGRES_PASSWORD              \
     :guid.doi.password=METACAT_GUID_DOI_PASSWORD      \
-    :replication.privatekey.password=METACAT_REPLICATION_PRIVATE_KEY_PASSWORD
+    :replication.privatekey.password=METACAT_REPLICATION_PRIVATE_KEY_PASSWORD \
+    :dataone.certificate.fromHttpHeader.proxyKey=METACAT_DATAONE_CERT_FROM_HTTP_HEADER_PROXY_KEY
 
 
 application.deployDir=

--- a/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
+++ b/test/edu/ucsb/nceas/metacat/properties/PropertiesWrapperTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 
 @RunWith(Suite.class)
 // Add new inner classes for tests grouped by functionality, to help with clarity, and so we
-// don't have to share @Before setup code where it's not needed. Each new inner classname should
+// don't have to share @Before setup code where it's not needed. Each new inner class name should
 // be added the @Suite.SuiteClasses test suite definition, below
 @Suite.SuiteClasses({
     PropertiesWrapperTest.EnvironmentVariablesTestSuite.class,
@@ -174,7 +174,7 @@ public class PropertiesWrapperTest {
     }
 
     /**
-     * Tests that exercise the ability to override secret credential properties by settign the
+     * Tests that exercise the ability to override secret credential properties by setting the
      * values as environment variables
      */
     public static class EnvironmentVariablesTestSuite {
@@ -190,15 +190,16 @@ public class PropertiesWrapperTest {
                 "POSTGRES_USER",
                 "POSTGRES_PASSWORD",
                 "METACAT_GUID_DOI_PASSWORD",
-                "METACAT_REPLICATION_PRIVATE_KEY_PASSWORD"
-
+                "METACAT_REPLICATION_PRIVATE_KEY_PASSWORD",
+                "METACAT_DATAONE_CERT_FROM_HTTP_HEADER_PROXY_KEY"
             };
             // These should be a subset of 'application.envSecretKeys' in metacat.properties
             final String[] secretPropsKeysList = {
                 "database.user",
                 "database.password",
                 "guid.doi.password",
-                "replication.privatekey.password"
+                "replication.privatekey.password",
+                "dataone.certificate.fromHttpHeader.proxyKey"
             };
             assertEquals(secretEnvVarKeysList.length, secretPropsKeysList.length);
 


### PR DESCRIPTION
Create and use a directory for 'solr.home' in the container, because HazelcastIndexEventLog still tries to write a file there.

Nothing else should write here (and hopefully Hazelcast won't, after it goes away)



