### PR TITLE
catalina props: ALLOW_ENCODED_SLASH and ALLOW_BACKSLASH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends  iputils-ping l
     rm -rf /var/lib/apt/lists/*                                                       && \
     mv /tmp/metacat.war /tmp/metacat-index.war /tmp/metacatui.war ${TC_HOME}/webapps  && \
     chown -R metacat ${TC_HOME}                                                       && \
+    echo "org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" \
+                                               >> ${TC_HOME}/conf/catalina.properties && \
+    echo "org.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true" \
+                                               >> ${TC_HOME}/conf/catalina.properties && \
     # Tomcat Mods - TODO MB - remove after Tomcat9 upgrade
     cp  ${TC_HOME}/conf/server.xml  ${TC_HOME}/conf/server.xml.original               && \
     sed -i 's/port="8080"/relaxedPathChars="\[\]\|" \


### PR DESCRIPTION
add lines to catalina props: ALLOW_ENCODED_SLASH and ALLOW_BACKSLASH. 

Fixes speedbagit download, D1 account lookup, and no doubt a bunch of other stuff