### PR TITLE
Feature 1665 k8s db auto update

### DIFF
--- a/src/edu/ucsb/nceas/metacat/MetaCatServlet.java
+++ b/src/edu/ucsb/nceas/metacat/MetaCatServlet.java
@@ -341,7 +341,7 @@ public class MetaCatServlet extends HttpServlet {
 			DBConnectionPool connPool = DBConnectionPool.getInstance();
 			logMetacat.debug("MetaCatServlet.initSecondHalf - DBConnection pool initialized: " + connPool.toString());
 
-			// Always check & auto-update DB if running in Kubernetes
+			// Always check & auto-update DB and MN settings if running in Kubernetes
 			if (Boolean.parseBoolean(System.getenv("METACAT_IS_RUNNING_IN_A_CONTAINER"))) {
 				K8sAdminInitializer.initializeK8sInstance();
 			}

--- a/src/edu/ucsb/nceas/metacat/startup/K8sAdminInitializer.java
+++ b/src/edu/ucsb/nceas/metacat/startup/K8sAdminInitializer.java
@@ -1,0 +1,177 @@
+package edu.ucsb.nceas.metacat.startup;
+
+import edu.ucsb.nceas.metacat.MetacatVersion;
+import edu.ucsb.nceas.metacat.admin.AdminException;
+import edu.ucsb.nceas.metacat.admin.D1Admin;
+import edu.ucsb.nceas.metacat.admin.DBAdmin;
+import edu.ucsb.nceas.metacat.database.DBVersion;
+import edu.ucsb.nceas.metacat.util.SystemUtil;
+import edu.ucsb.nceas.utilities.GeneralPropertyException;
+import edu.ucsb.nceas.utilities.PropertyNotFoundException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.servlet.ServletException;
+
+/**
+ * Collection of administrative initialization tasks that need to be performed automatically on
+ * startup, when running in Kubernetes. Typically, the public <code>initializeK8sInstance()</code>
+ * method is called during system startup - eg from the servlet <code>init()</code> method.
+ *
+ * (In legacy deployments, these tasks are carried out manually, using the admin UI. However,
+ * this isn't possible or desirable in Kubernetes, since the site properties file is a read-only
+ * configmap)
+ */
+public class K8sAdminInitializer {
+
+    private static final Log logMetacat = LogFactory.getLog(K8sAdminInitializer.class);
+
+    /**
+     * private constructor, since this is a singleton
+     */
+    private K8sAdminInitializer() {
+    }
+
+    public static void initializeK8sInstance() throws ServletException {
+
+        logMetacat.info("initializeK8sInstance() called...");
+
+        if (!isK8sInstance()) {
+            throw new ServletException("initializeK8sInstance() called, but Metacat is NOT "
+                                           + "running in a container (or the "
+                                           + "METACAT_IS_RUNNING_IN_A_CONTAINER env var has not "
+                                           + "been set correctly)");
+        }
+
+        //check database and update if necessary
+        initK8sDBConfig();
+
+        // check D1 Admin settings and update if necessary
+        initK8sD1Admin();
+    }
+
+
+    /**
+     * Check if we're running in a container/Kubernetes, and if so, call the DBAdmin code to
+     * check for and perform any database updates that may be necessary.
+     *
+     * If this is a legacy deployment (i.e. not containerized/k8s), this method does nothing, since
+     * database updates are performed manually, via the admin pages.
+     *
+     * @throws ServletException if updates were unsuccessful
+     */
+    void initializeContainerizedDBConfiguration() throws ServletException {
+        if (isContainerized()) {
+            logMetacat.info("Running in a container; checking for necessary database updates...");
+            MetacatVersion metacatVersion;
+            DBVersion dbVersion;
+            String mcVerStr = "NULL";
+            String dbVerStr = "NULL";
+            try {
+                metacatVersion = SystemUtil.getMetacatVersion();
+                mcVerStr = metacatVersion.getVersionString();
+                dbVersion = DBAdmin.getInstance().getDBVersion();
+                dbVerStr = dbVersion.getVersionString();
+                if (metacatVersion.compareTo(dbVersion) == 0) {
+                    // ALREADY UPGRADED
+                    logMetacat.info("initializeContainerisedDBConfiguration(): NO DATABASE "
+                                        + "UPDATES REQUIRED, since database version (" + dbVerStr
+                                        + ") matches metacat version (" + mcVerStr + ").");
+                } else {
+                    // NEEDS UPGRADE
+                    logMetacat.info("initializeContainerisedDBConfiguration(): UPDATING DATABASE, "
+                                        + "since database version (" + dbVerStr
+                                        + ") is behind Metacat version (" + mcVerStr + ").");
+                    DBAdmin.getInstance().upgradeDatabase();
+                }
+            } catch (AdminException | PropertyNotFoundException e) {
+                String msg =
+                    "initializeContainerisedDBConfiguration(): error getting metacat version ("
+                        + mcVerStr + ") or database version (" + dbVerStr + "). Error was: "
+                        + e.getMessage();
+                logMetacat.error(msg, e);
+                ServletException se = new ServletException(msg, e);
+                se.fillInStackTrace();
+                throw se;
+            }
+        } else {
+            logMetacat.info("NOT Running in a container; no automatic database updates");
+        }
+    }
+
+    /**
+     * Checks the environment variable "METACAT_IS_RUNNING_IN_A_CONTAINER", set by the helm
+     * chart, to determine if this instance is running in Kubernetes
+     *
+     * @return true if this instance is running in a container; false otherwise
+     */
+    public static boolean isK8sInstance() {
+        return Boolean.parseBoolean(System.getenv("METACAT_IS_RUNNING_IN_A_CONTAINER"));
+    }
+
+    /**
+     * Call the DBAdmin code to check for and perform any database updates that may be necessary.
+     *
+     * @throws ServletException if updates were unsuccessful
+     */
+    static void initK8sDBConfig() throws ServletException {
+
+        logMetacat.info("initK8sDBConfig(): checking for necessary database updates...");
+        MetacatVersion metacatVersion;
+        DBVersion dbVersion;
+        String mcVerStr = "NULL";
+        String dbVerStr = "NULL";
+        try {
+            metacatVersion = SystemUtil.getMetacatVersion();
+            mcVerStr = metacatVersion.getVersionString();
+            dbVersion = DBAdmin.getInstance().getDBVersion();
+            dbVerStr = dbVersion.getVersionString();
+            if (metacatVersion.compareTo(dbVersion) == 0) {
+                // ALREADY UPGRADED
+                logMetacat.info(
+                    "initK8sDBConfig(): NO DATABASE UPDATES REQUIRED, since database " + "version ("
+                        + dbVerStr + ") matches metacat version (" + mcVerStr + ").");
+            } else {
+                // NEEDS UPGRADE
+                logMetacat.info(
+                    "initK8sDBConfig(): UPDATING DATABASE, " + "since database version (" + dbVerStr
+                        + ") is behind Metacat version (" + mcVerStr + ").");
+                DBAdmin.getInstance().upgradeDatabase();
+            }
+        } catch (AdminException | PropertyNotFoundException e) {
+            String msg = "initializeContainerisedDBConfiguration(): error getting metacat version ("
+                + mcVerStr + ") or database version (" + dbVerStr + "). Error was: "
+                + e.getMessage();
+            logMetacat.error(msg, e);
+            ServletException se = new ServletException(msg, e);
+            se.fillInStackTrace();
+            throw se;
+        }
+    }
+
+    /**
+     * Check if we're running in a container/Kubernetes, and if so, call the D1Admin
+     * upRegD1MemberNode() method to handle DataONE Member Node registration or updates that may be
+     * necessary. If this is a legacy deployment (i.e. not containerized/k8s), this method does
+     * nothing, since Member Node updates are performed manually, via the admin pages.
+     *
+     * @throws ServletException if MN updates were unsuccessful
+     */
+    static void initK8sD1Admin() throws ServletException {
+        if (D1AdminCNUpdater.isMetacatRunningInAContainer()) {
+            logMetacat.info("Running in a container; calling D1Admin::upRegD1MemberNode");
+            try {
+                D1Admin.getInstance().upRegD1MemberNode();
+            } catch (GeneralPropertyException | AdminException e) {
+                String msg = "initializeContainerizedD1Admin(): error calling "
+                    + "D1Admin.getInstance().upRegD1MemberNode: " + e.getMessage();
+                logMetacat.error(msg, e);
+                ServletException se = new ServletException(msg, e);
+                se.fillInStackTrace();
+                throw se;
+            }
+        } else {
+            logMetacat.info("NOT Running in a container; no automatic D1MemberNode updates");
+        }
+    }
+}

--- a/src/edu/ucsb/nceas/metacat/startup/K8sAdminInitializer.java
+++ b/src/edu/ucsb/nceas/metacat/startup/K8sAdminInitializer.java
@@ -16,10 +16,10 @@ import javax.servlet.ServletException;
 /**
  * Collection of administrative initialization tasks that need to be performed automatically on
  * startup, when running in Kubernetes. Typically, the public <code>initializeK8sInstance()</code>
- * method is called during system startup - eg from the servlet <code>init()</code> method.
+ * method is called during system startup - e.g. from the servlet <code>init()</code> method.
  *
- * (In legacy deployments, these tasks are carried out manually, using the admin UI. However,
- * this isn't possible or desirable in Kubernetes, since the site properties file is a read-only
+ * (In legacy deployments, these tasks are carried out manually, using the admin UI. However, this
+ * isn't possible or desirable in Kubernetes, since the site properties file is a read-only
  * configmap)
  */
 public class K8sAdminInitializer {
@@ -32,16 +32,18 @@ public class K8sAdminInitializer {
     private K8sAdminInitializer() {
     }
 
+    /**
+     * Method to be called during system startup - e.g. from the servlet <code>init()</code> method
+     * . This method, in turn, will verify that this is a containerized/k8s instance, and then
+     * will perform the necessary initialization steps
+     *
+     * @throws ServletException if anything goes wrong
+     */
     public static void initializeK8sInstance() throws ServletException {
 
-        logMetacat.info("initializeK8sInstance() called...");
+        verifyK8s();
 
-        if (!isK8sInstance()) {
-            throw new ServletException("initializeK8sInstance() called, but Metacat is NOT "
-                                           + "running in a container (or the "
-                                           + "METACAT_IS_RUNNING_IN_A_CONTAINER env var has not "
-                                           + "been set correctly)");
-        }
+        logMetacat.info("initializeK8sInstance() configuring for K8s environment...");
 
         //check database and update if necessary
         initK8sDBConfig();
@@ -50,69 +52,28 @@ public class K8sAdminInitializer {
         initK8sD1Admin();
     }
 
-
     /**
-     * Check if we're running in a container/Kubernetes, and if so, call the DBAdmin code to
-     * check for and perform any database updates that may be necessary.
+     * Checks the environment variable "METACAT_IS_RUNNING_IN_A_CONTAINER", set by the helm chart,
+     * to verify that this instance is running in Kubernetes.
      *
-     * If this is a legacy deployment (i.e. not containerized/k8s), this method does nothing, since
-     * database updates are performed manually, via the admin pages.
-     *
-     * @throws ServletException if updates were unsuccessful
+     * @throws ServletException if this instance is NOT running in a container
+     * @implNote package private to allow for unit testing
      */
-    void initializeContainerizedDBConfiguration() throws ServletException {
-        if (isContainerized()) {
-            logMetacat.info("Running in a container; checking for necessary database updates...");
-            MetacatVersion metacatVersion;
-            DBVersion dbVersion;
-            String mcVerStr = "NULL";
-            String dbVerStr = "NULL";
-            try {
-                metacatVersion = SystemUtil.getMetacatVersion();
-                mcVerStr = metacatVersion.getVersionString();
-                dbVersion = DBAdmin.getInstance().getDBVersion();
-                dbVerStr = dbVersion.getVersionString();
-                if (metacatVersion.compareTo(dbVersion) == 0) {
-                    // ALREADY UPGRADED
-                    logMetacat.info("initializeContainerisedDBConfiguration(): NO DATABASE "
-                                        + "UPDATES REQUIRED, since database version (" + dbVerStr
-                                        + ") matches metacat version (" + mcVerStr + ").");
-                } else {
-                    // NEEDS UPGRADE
-                    logMetacat.info("initializeContainerisedDBConfiguration(): UPDATING DATABASE, "
-                                        + "since database version (" + dbVerStr
-                                        + ") is behind Metacat version (" + mcVerStr + ").");
-                    DBAdmin.getInstance().upgradeDatabase();
-                }
-            } catch (AdminException | PropertyNotFoundException e) {
-                String msg =
-                    "initializeContainerisedDBConfiguration(): error getting metacat version ("
-                        + mcVerStr + ") or database version (" + dbVerStr + "). Error was: "
-                        + e.getMessage();
-                logMetacat.error(msg, e);
-                ServletException se = new ServletException(msg, e);
-                se.fillInStackTrace();
-                throw se;
-            }
-        } else {
-            logMetacat.info("NOT Running in a container; no automatic database updates");
+    static void verifyK8s() throws ServletException {
+        if (!Boolean.parseBoolean(System.getenv("METACAT_IS_RUNNING_IN_A_CONTAINER"))) {
+            throw new ServletException("initializeK8sInstance() called, but Metacat is NOT "
+                                           + "running in a container (or the "
+                                           + "METACAT_IS_RUNNING_IN_A_CONTAINER env var has not "
+                                           + "been set correctly)");
         }
     }
 
     /**
-     * Checks the environment variable "METACAT_IS_RUNNING_IN_A_CONTAINER", set by the helm
-     * chart, to determine if this instance is running in Kubernetes
-     *
-     * @return true if this instance is running in a container; false otherwise
-     */
-    public static boolean isK8sInstance() {
-        return Boolean.parseBoolean(System.getenv("METACAT_IS_RUNNING_IN_A_CONTAINER"));
-    }
-
-    /**
      * Call the DBAdmin code to check for and perform any database updates that may be necessary.
+     * (In a non-k8s environment, database updates are performed manually, via the admin UI)
      *
      * @throws ServletException if updates were unsuccessful
+     * @implNote package private to allow for unit testing
      */
     static void initK8sDBConfig() throws ServletException {
 
@@ -150,28 +111,24 @@ public class K8sAdminInitializer {
     }
 
     /**
-     * Check if we're running in a container/Kubernetes, and if so, call the D1Admin
-     * upRegD1MemberNode() method to handle DataONE Member Node registration or updates that may be
-     * necessary. If this is a legacy deployment (i.e. not containerized/k8s), this method does
-     * nothing, since Member Node updates are performed manually, via the admin pages.
+     * Call the D1Admin upRegD1MemberNode() method to handle DataONE Member Node registration or
+     * updates that may be necessary. (In a non-k8s environment, Member Node updates are performed
+     * manually, via the admin UI)
      *
      * @throws ServletException if MN updates were unsuccessful
+     * @implNote package private to allow for unit testing
      */
     static void initK8sD1Admin() throws ServletException {
-        if (D1AdminCNUpdater.isMetacatRunningInAContainer()) {
-            logMetacat.info("Running in a container; calling D1Admin::upRegD1MemberNode");
-            try {
-                D1Admin.getInstance().upRegD1MemberNode();
-            } catch (GeneralPropertyException | AdminException e) {
-                String msg = "initializeContainerizedD1Admin(): error calling "
-                    + "D1Admin.getInstance().upRegD1MemberNode: " + e.getMessage();
-                logMetacat.error(msg, e);
-                ServletException se = new ServletException(msg, e);
-                se.fillInStackTrace();
-                throw se;
-            }
-        } else {
-            logMetacat.info("NOT Running in a container; no automatic D1MemberNode updates");
+        logMetacat.info("Running in a container; calling D1Admin::upRegD1MemberNode");
+        try {
+            D1Admin.getInstance().upRegD1MemberNode();
+        } catch (GeneralPropertyException | AdminException e) {
+            String msg = "initializeContainerizedD1Admin(): error calling "
+                + "D1Admin.getInstance().upRegD1MemberNode: " + e.getMessage();
+            logMetacat.error(msg, e);
+            ServletException se = new ServletException(msg, e);
+            se.fillInStackTrace();
+            throw se;
         }
     }
 }

--- a/src/edu/ucsb/nceas/metacat/startup/StartupRequirementsListener.java
+++ b/src/edu/ucsb/nceas/metacat/startup/StartupRequirementsListener.java
@@ -1,4 +1,4 @@
-package edu.ucsb.nceas.metacat.healthchecks;
+package edu.ucsb.nceas.metacat.startup;
 
 import edu.ucsb.nceas.metacat.properties.PropertyService;
 import org.apache.commons.logging.Log;

--- a/test/edu/ucsb/nceas/metacat/MetaCatServletTest.java
+++ b/test/edu/ucsb/nceas/metacat/MetaCatServletTest.java
@@ -1,7 +1,5 @@
 package edu.ucsb.nceas.metacat;
 
-import edu.ucsb.nceas.LeanTestUtils;
-import edu.ucsb.nceas.metacat.admin.D1Admin;
 import org.apache.commons.configuration.Configuration;
 import org.dataone.configuration.Settings;
 import org.junit.Before;
@@ -32,13 +30,6 @@ import static org.junit.Assert.*;
  */
 public class MetaCatServletTest {
 
-    private MetaCatServlet mcServlet;
-
-    @Before
-    public void setUp() throws Exception {
-        mcServlet = new MetaCatServlet();
-    }
-
     @Test
     public void isReadOnly() throws IOException {
         HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
@@ -59,32 +50,6 @@ public class MetaCatServletTest {
             assertTrue(MetaCatServlet.isReadOnly(mockResponse));
             assertTrue("Actual response was: " + stringWriter.toString(),
                        stringWriter.toString().contains("Metacat is in read-only mode"));
-        }
-    }
-
-    @Test
-    public void initializeContainerizedD1Admin() throws Exception {
-
-        final String CONTAINERIZED = "METACAT_IS_RUNNING_IN_A_CONTAINER";
-
-        try (MockedStatic<D1Admin> ignored = Mockito.mockStatic(D1Admin.class)) {
-            D1Admin mockD1Admin = Mockito.mock(D1Admin.class);
-            Mockito.when(D1Admin.getInstance()).thenReturn(mockD1Admin);
-            Mockito.doNothing().when(mockD1Admin).upRegD1MemberNode();
-
-            // K8s mode
-            LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "true");
-            mcServlet.initializeContainerizedD1Admin();
-
-            // Verify that upRegD1MemberNode() was called
-            Mockito.verify(mockD1Admin, Mockito.times(1)).upRegD1MemberNode();
-
-            // Legacy mode
-            LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "false");
-            mcServlet.initializeContainerizedD1Admin();
-
-            // Verify that upRegD1MemberNode() was not called again (should still be 1)
-            Mockito.verify(mockD1Admin, Mockito.times(1)).upRegD1MemberNode();
         }
     }
 }

--- a/test/edu/ucsb/nceas/metacat/startup/K8sAdminInitializerTest.java
+++ b/test/edu/ucsb/nceas/metacat/startup/K8sAdminInitializerTest.java
@@ -1,0 +1,124 @@
+package edu.ucsb.nceas.metacat.startup;
+
+import edu.ucsb.nceas.LeanTestUtils;
+import edu.ucsb.nceas.metacat.MetacatVersion;
+import edu.ucsb.nceas.metacat.admin.D1Admin;
+import edu.ucsb.nceas.metacat.admin.DBAdmin;
+import edu.ucsb.nceas.metacat.database.DBVersion;
+import edu.ucsb.nceas.metacat.properties.PropertyService;
+import edu.ucsb.nceas.metacat.util.SystemUtil;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+
+public class K8sAdminInitializerTest {
+
+    private static final String CONTAINERIZED = "METACAT_IS_RUNNING_IN_A_CONTAINER";
+
+
+    @Test(expected = ServletException.class)
+    public void initializeK8sInstance_exception() throws Exception {
+        // Legacy mode
+        LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "false");
+        K8sAdminInitializer.initializeK8sInstance();
+    }
+
+    @Test
+    public void verifyK8s() throws Exception {
+        // Legacy mode
+        LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "true");
+        K8sAdminInitializer.verifyK8s();
+        assertTrue("Should get here without throwing an exception", true);
+    }
+
+    @Test(expected = ServletException.class)
+    public void verifyK8s_exception() throws Exception {
+        // Legacy mode
+        LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "false");
+        K8sAdminInitializer.verifyK8s();
+    }
+
+    @Test
+    public void initK8sDBConfig() throws Exception {
+
+        final String V0 = "0.0.0";
+        final String V2 = "2.19.0";
+        final String V3 = "3.0.0";
+        final String LATEST = "3.0.1";
+        MetacatVersion mcV_LATEST = new MetacatVersion(LATEST);
+        LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "true");
+
+        try (MockedStatic<PropertyService> ignored = Mockito.mockStatic(PropertyService.class)) {
+            PropertyService mockProps = Mockito.mock(PropertyService.class);
+            Mockito.when(PropertyService.getInstance()).thenReturn(mockProps);
+            Mockito.when(PropertyService.getProperty(anyString())).thenReturn("MOCK");
+
+            DBVersion dbV_0 = new DBVersion(V0);
+            DBVersion dbV_2 = new DBVersion(V2);
+            DBVersion dbV_3 = new DBVersion(V3);
+            DBVersion dbV_LATEST = new DBVersion(LATEST);
+
+            try (MockedStatic<DBAdmin> ignored2 = Mockito.mockStatic(DBAdmin.class)) {
+                DBAdmin mockDBAdmin = Mockito.mock(DBAdmin.class);
+                Mockito.when(DBAdmin.getInstance()).thenReturn(mockDBAdmin);
+                doNothing().when(mockDBAdmin).upgradeDatabase();
+
+                try (MockedStatic<SystemUtil> ignored3 = Mockito.mockStatic(SystemUtil.class)) {
+
+                    Mockito.when(SystemUtil.getMetacatVersion()).thenReturn(mcV_LATEST);
+
+                    // starting condition: Verify that upgradeDatabase() not yet called (times =0)
+                    Mockito.verify(mockDBAdmin, Mockito.times(0)).upgradeDatabase();
+
+                    // DB v0.0.0 (new) & MC v3.0.1; Verify that upgradeDatabase() was called
+                    // (times =1)
+                    Mockito.when(mockDBAdmin.getDBVersion()).thenReturn(dbV_0);
+                    K8sAdminInitializer.initK8sDBConfig();
+                    Mockito.verify(mockDBAdmin, Mockito.times(1)).upgradeDatabase();
+
+                    // DB v2.19.0 & MC v3.0.1; Verify that upgradeDatabase() was called again
+                    // (times =2)
+                    Mockito.when(mockDBAdmin.getDBVersion()).thenReturn(dbV_2);
+                    K8sAdminInitializer.initK8sDBConfig();
+                    Mockito.verify(mockDBAdmin, Mockito.times(2)).upgradeDatabase();
+
+                    // DB v3.0.0 & MC v3.0.1; Verify that upgradeDatabase() was called again
+                    // (times =3)
+                    Mockito.when(mockDBAdmin.getDBVersion()).thenReturn(dbV_3);
+                    K8sAdminInitializer.initK8sDBConfig();
+                    Mockito.verify(mockDBAdmin, Mockito.times(3)).upgradeDatabase();
+
+                    // DB v3.0.1 & MC v3.0.1; Verify that upgradeDatabase() was NOT called (still
+                    // =3)
+                    Mockito.when(mockDBAdmin.getDBVersion()).thenReturn(dbV_LATEST);
+                    K8sAdminInitializer.initK8sDBConfig();
+                    Mockito.verify(mockDBAdmin, Mockito.times(3)).upgradeDatabase();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void initK8sD1Admin() throws Exception {
+
+        try (MockedStatic<D1Admin> ignored = Mockito.mockStatic(D1Admin.class)) {
+            D1Admin mockD1Admin = Mockito.mock(D1Admin.class);
+            Mockito.when(D1Admin.getInstance()).thenReturn(mockD1Admin);
+            doNothing().when(mockD1Admin).upRegD1MemberNode();
+
+            // K8s mode
+            Mockito.verify(mockD1Admin, Mockito.times(0)).upRegD1MemberNode();
+            LeanTestUtils.setTestEnvironmentVariable(CONTAINERIZED, "true");
+            K8sAdminInitializer.initK8sD1Admin();
+
+            // Verify that upRegD1MemberNode() was called
+            Mockito.verify(mockD1Admin, Mockito.times(1)).upRegD1MemberNode();
+        }
+    }
+}

--- a/test/edu/ucsb/nceas/metacat/startup/StartupRequirementsListenerTest.java
+++ b/test/edu/ucsb/nceas/metacat/startup/StartupRequirementsListenerTest.java
@@ -1,4 +1,4 @@
-package edu.ucsb.nceas.metacat.healthchecks;
+package edu.ucsb.nceas.metacat.startup;
 
 import edu.ucsb.nceas.LeanTestUtils;
 import edu.ucsb.nceas.metacat.properties.PropertyService;


### PR DESCRIPTION
1. Pulled out Member Node initialization from metacat servlet into its own class (`K8sAdminInitializer`) and did same for unit tests
2. In this new class, also added automatic database initialization when running under k8s (and added tests for this)
3. Removed hacky `curl` method of logging into admin and running DB updates from `docker-entrypoint.sh`