### PR TITLE
Upgraded the postgresql jdbc library to 42.6.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
                     <groupId>edu.uiuc.ncsa.myproxy</groupId>
                     <artifactId>oa4mp-client-oauth1</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -280,15 +284,10 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>8.0-312.jdbc3</version>
+            <version>42.6.0</version>
         </dependency>
-        <!-- <dependency>
-            <groupId>org.apache.solr</groupId>
-            <artifactId>solr-core</artifactId>
-            <version>3.4.0</version>
-        </dependency>-->
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>

--- a/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
+++ b/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
@@ -190,6 +190,13 @@ public class SystemMetadataManager {
                 } finally {
                     if (dbConn != null) {
                         // Return database connection to the pool
+                        try {
+                            dbConn.setAutoCommit(true);
+                        } catch (SQLException e) {
+                            logMetacat.warn("SystemMetadataManager.store - can't set the "
+                                            + "auto-commit back to true for the connection since "
+                                            + e.getMessage());
+                        }
                         DBConnectionPool.returnDBConnection(dbConn, serialNumber);
                     }
                 }
@@ -479,7 +486,6 @@ public class SystemMetadataManager {
             PreparedStatement stmt = null;
             PreparedStatement stmt2 = null;
         try {
-            dbConn.setAutoCommit(false);
             // Execute the insert statement
             String query = "update " + IdentifierManager.TYPE_SYSTEM_METADATA + 
                 " set (date_uploaded, rights_holder, checksum, checksum_algorithm, " +
@@ -542,12 +548,7 @@ public class SystemMetadataManager {
                     
                 }
             }
-            dbConn.commit();
-            dbConn.setAutoCommit(true);
         } catch (Exception e) {
-            dbConn.rollback();
-            dbConn.setAutoCommit(true);
-            e.printStackTrace();
             throw new SQLException(e.getMessage());
         } finally {
             if(stmt != null) {


### PR DESCRIPTION
The PR did two tasks:
1. Upgraded the PostgreSQL JDBC library to version 42.6.0, the latest version.
2. Fixed a bug that Metacat tried to call conn.commit() when the conn is set auto-commit in the SystemMetadataManager class. This bug was found by the new library.

The ticket about this PR is [here](https://github.com/NCEAS/metacat/issues/1183)