### PR TITLE
script to list and back up all sysmeta that doesn't have an identifie…

### DIFF
--- a/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
+++ b/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
@@ -18,10 +18,10 @@ if [ -z "$PGPASSWORD" ]; then
     exit 2
 fi
 if [ -z "$METACAT_BASE_URL" ]; then
-    echo "Requires 'METACAT_BASE_URL' env variable containing the protocol, host and optional"
-    echo "port number. Examples:"
-    echo "        export METACAT_BASE_URL=\"http://localhost:8080\""
-    echo "        export METACAT_BASE_URL=\"https://arcticdata.io\""
+    echo "Requires 'METACAT_BASE_URL' env variable containing the protocol, host, optional"
+    echo "port number, and context name. Examples:"
+    echo "        export METACAT_BASE_URL=\"http://localhost:8080/knb\""
+    echo "        export METACAT_BASE_URL=\"https://arcticdata.io/metacat\""
     exit 3
 fi
 
@@ -72,7 +72,7 @@ IFS=$'\n'
 COUNT=0
 for row in $RESULT_AC; do
     guid=$(echo $row | cut -d '|' -f 1)
-    url="$METACAT_BASE_URL/metacat/d1/mn/v2/meta/${guid}"
+    url="$METACAT_BASE_URL/d1/mn/v2/meta/${guid}"
     echo "Retrieving from: $url"
     curl --silent -H "Authorization: Bearer $TOKEN" -o sysmeta/${guid}.xml $url && COUNT=$(($COUNT+1))
 done

--- a/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
+++ b/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# NONDESTRUCTIVE script to retrieve and then back up locally any `systemmetadata` records without a
+# corresponding `identifier` record, that were created or updated after 10/26/2023 - first ever
+# possible use of chrome v120 (Android beta - unlikely to be so early, but better to be cautious)
+# https://chromereleases.googleblog.com/search?updated-max=2023-10-31T14:06:00-07:00&max-results=7&start=35&by-date=false
+#
+
+DATABASE_NAME="metacat"
+DATABASE_USER="metacat"
+
+if [ -z "$TOKEN" ]; then
+    echo "Requires 'TOKEN' env variable containing JWT token with access to all private packages"
+    exit 1
+fi
+if [ -z "$PGPASSWORD" ]; then
+    echo "Requires 'PGPASSWORD' env variable containing password for metacat db user"
+    exit 2
+fi
+if [ -z "$METACAT_BASE_URL" ]; then
+    echo "Requires 'METACAT_BASE_URL' env variable containing the protocol, host and optional"
+    echo "port number. Examples:"
+    echo "        export METACAT_BASE_URL=\"http://localhost:8080\""
+    echo "        export METACAT_BASE_URL=\"https://arcticdata.io\""
+    exit 3
+fi
+
+
+#1) Run a query against the local PostgreSQL database to get the list of guid, docid, rev,
+# date_uploaded, date_modified values:
+#
+
+echo "Step 1: Get the list of affected systemmetadata entries from postgres..."
+
+# date (2023-10-26 00:00:00) as a Unix timestamp. Can get via:
+# GNU/UNIX:     CUTOFF_DATE=$(date -d "2023-10-26 00:00:00" +%s)
+# MacOs:        CUTOFF_DATE=$(date -j -f "%Y-%m-%d %H:%M:%S" "2023-10-26 00:00:00" "+%s")
+#CUTOFF_DATE="1698303600"
+CUTOFF_DATE=$(date -j -f "%Y-%m-%d %H:%M:%S" "2023-10-26 00:00:00" "+%s")
+
+QUERY_START="SELECT sm.guid, i.docid, i.rev, sm.date_uploaded, sm.date_modified \
+FROM systemmetadata sm LEFT JOIN identifier i ON (sm.guid = i.guid) WHERE i.guid IS NULL AND ("
+
+QUERY_END=") ORDER BY date_modified DESC;"
+
+# First query: records where date_uploaded or date_modified is BEFORE or AT midnight on 10/25/2023
+QUERY_BC="$QUERY_START \
+sm.date_uploaded <= to_timestamp($CUTOFF_DATE) OR sm.date_modified <= to_timestamp($CUTOFF_DATE) \
+$QUERY_END"
+RESULT_BC=$(psql -h localhost -U $DATABASE_USER -d $DATABASE_NAME -tAX -c "$QUERY_BC")
+
+echo; echo "systemmetadata entries UNRELATED to Chrome v120 bug:"
+echo; echo "guid    |    docid    |    rev    |    sm.date_uploaded    |    sm.date_modified"
+echo "${RESULT_BC}"
+
+# Second query: records where date_uploaded or date_modified is AFTER midnight on 10/26/2023
+QUERY_AC="$QUERY_START \
+sm.date_uploaded > to_timestamp($CUTOFF_DATE) OR sm.date_modified > to_timestamp($CUTOFF_DATE) \
+$QUERY_END"
+RESULT_AC=$(psql -h localhost -U $DATABASE_USER -d $DATABASE_NAME -tAX -c "$QUERY_AC")
+
+echo; echo "systemmetadata entries likely caused by Chrome v120 bug:"
+echo; echo "guid    |    docid    |    rev    |    sm.date_uploaded    |    sm.date_modified"
+echo "${RESULT_AC}"
+
+#For each value of guid, make a call to API and save the returned XML document to disk in the
+# "sysmeta" subdirectory of the current working directory:
+#
+echo; echo; echo "Making localhost backups of systemmetadata docs"
+mkdir -p sysmeta
+IFS=$'\n'
+COUNT=0
+for row in $RESULT_AC; do
+    guid=$(echo $row | cut -d '|' -f 1)
+    url="$METACAT_BASE_URL/metacat/d1/mn/v2/meta/${guid}"
+    echo "Retrieving from: $url"
+    curl --silent -H "Authorization: Bearer $TOKEN" -o sysmeta/${guid}.xml $url && COUNT=$(($COUNT+1))
+done
+unset IFS
+
+echo; echo "FINISHED! Backed up $COUNT systemmetadata files are directory: $(pwd)/sysmeta/"

--- a/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
+++ b/src/scripts/bash/Chrome120_sysmetaclean_1_CREATE_BACKUPS.sh
@@ -87,6 +87,10 @@ for row in $RESULT_AC; do
     url="$METACAT_BASE_URL/d1/mn/v2/meta/${guid}"
     echo "Retrieving from: $url"
     curl --silent -H "Authorization: Bearer $TOKEN" -o sysmeta/${guid}.xml $url && COUNT=$(($COUNT+1))
+    if [[ $( cat sysmeta/${guid}.xml | grep -c "checksum" ) == "0" ]]; then
+      echo "ERROR: file sysmeta/${guid}.xml is NOT VALID SYSMETA. Check that your TOKEN is valid!"
+      exit 3
+    fi
 done
 unset IFS
 

--- a/src/scripts/bash/Chrome120_sysmetaclean_2_DELETE.sh
+++ b/src/scripts/bash/Chrome120_sysmetaclean_2_DELETE.sh
@@ -45,7 +45,8 @@ CUTOFF_DATE="1698303600"
 
 SELECT_QUERY=\
 "SELECT sm.guid                                                                                \
-FROM systemmetadata sm LEFT JOIN identifier i ON (sm.guid = i.guid) WHERE i.guid IS NULL AND ( \
+FROM systemmetadata sm LEFT JOIN identifier i ON (sm.guid = i.guid) WHERE i.guid IS NULL \
+AND sm.obsoleted_by IS NULL AND sm.obsoletes IS NULL AND ( \
 sm.date_uploaded > to_timestamp($CUTOFF_DATE) OR sm.date_modified > to_timestamp($CUTOFF_DATE) \
 ) ORDER BY date_modified DESC"
 SELECT_RESULTS=$(psql -h localhost -U $DATABASE_USER -d $DATABASE_NAME -tAX -c "$SELECT_QUERY")

--- a/src/scripts/bash/Chrome120_sysmetaclean_2_DELETE.sh
+++ b/src/scripts/bash/Chrome120_sysmetaclean_2_DELETE.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#
+# Script to * * * DELETE * * *  from the database, any systemmetadata
+# records without an identifier record, that were created or updated after 10/26/2023 - first ever
+# possible use of chrome v120 (Android beta) - unlikely to be so early, but better to be cautious
+# https://chromereleases.googleblog.com/search?updated-max=2023-10-31T14:06:00-07:00&max-results=7&start=35&by-date=false
+#
+# DELETE *should* be safe, because without an identifier record, we have no way of linking the
+# sysmeta to any other tables, as they all use docid/rev as their primary keys (xml_documents,
+# xml_revisions, xml_access, etc).
+#
+# Files are also named by their docid/rev, so we have no way of tracking the sysmeta to a file path
+#
+
+DATABASE_NAME="metacat"
+DATABASE_USER="metacat"
+
+
+if [[ -z $1 ]] || [[ $1 -ne "-CONFIRM_DELETE" ]]; then
+    echo "* * * * * *  C A U T I O N  * * * * * *"
+    echo "This script DELETES database entries. Please make sure"
+    echo "you have done the following before executing:"
+    echo "  First, read the comments in this file."
+    echo "  Then ensure that the following values are correct:"
+    echo "    DATABASE_NAME: $DATABASE_NAME"
+    echo "    DATABASE_USER: $DATABASE_USER"
+    echo "  (if not, edit the values bin this file.)"
+    echo "Finally, when you are sure you want to proceed, use the command:"
+    echo "        $0 -CONFIRM_DELETE"
+    echo
+    exit 1
+fi
+if [ -z "$PGPASSWORD" ]; then
+    echo "WARNING: Optional 'PGPASSWORD' env variable containing database user password not set"
+    echo "You may get prompted to enter the password"
+fi
+
+# date (2023-10-26 00:00:00) as a Unix timestamp. Can get via:
+# GNU/UNIX:     CUTOFF_DATE=$(date -d "2023-10-26 00:00:00" +%s)
+# MacOs:        CUTOFF_DATE=$(date -j -f "%Y-%m-%d %H:%M:%S" "2023-10-26 00:00:00" "+%s")
+# but "1698303600" is the final unix timestamp value for 2023-10-26 00:00:00
+#
+CUTOFF_DATE="1698303600"
+
+SELECT_QUERY=\
+"SELECT sm.guid                                                                                \
+FROM systemmetadata sm LEFT JOIN identifier i ON (sm.guid = i.guid) WHERE i.guid IS NULL AND ( \
+sm.date_uploaded > to_timestamp($CUTOFF_DATE) OR sm.date_modified > to_timestamp($CUTOFF_DATE) \
+) ORDER BY date_modified DESC"
+SELECT_RESULTS=$(psql -h localhost -U $DATABASE_USER -d $DATABASE_NAME -tAX -c "$SELECT_QUERY")
+
+ROW_COUNT=$(echo $SELECT_RESULTS | wc -w)
+
+echo; echo "Found guids for $ROW_COUNT systemmetadata entries likely caused by Chrome v120 bug:"
+echo "${SELECT_RESULTS}"
+
+echo; echo "NOW DELETING these $ROW_COUNT systemmetadata entries..."
+
+DELETE_QUERY="DELETE from systemmetadata sm WHERE sm.guid in ( $SELECT_QUERY );"
+
+DELETE_RESULTS=$(psql -h localhost -U $DATABASE_USER -d $DATABASE_NAME -tAX -c "$DELETE_QUERY")
+
+echo "DELETED!"
+echo
+echo "${DELETE_RESULTS}"


### PR DESCRIPTION
scripts to back up and clean up orphaned sysmeta due to Chrome 120 bug - one to list & back up, and another to delete