### PR TITLE
add conditional DBConnectionPool init

### DIFF
--- a/src/edu/ucsb/nceas/metacat/startup/MetacatInitializer.java
+++ b/src/edu/ucsb/nceas/metacat/startup/MetacatInitializer.java
@@ -83,6 +83,9 @@ public class MetacatInitializer implements ServletContextListener{
             // If both are false then stop the initialization
             if (!ConfigurationUtil.bypassConfiguration() &&
                                     !ConfigurationUtil.isMetacatConfigured()) {
+                if (PropertyService.arePropertiesConfigured()) {
+                    DBConnectionPool.getInstance();
+                }
                 fullInit = false;
                 return;
             }


### PR DESCRIPTION
In mc 2.19, DBConnectionPool.getInstance() was being called earlier by MetacatServlet. Now that's gone away in 3.0, the DB connection was not initialized early enough under the specific circumstances detailed in Issue #1809 