### PR TITLE
Feature-1804: Admin Token Path (Highlight New Properties)

### DIFF
--- a/docs/user/metacat/source/metacat-properties.rst
+++ b/docs/user/metacat/source/metacat-properties.rst
@@ -173,12 +173,8 @@ others are managed with the properties configuration utility.
 +--------------------------------------+-----------------------------------------------------------------------------+-------------------------------+
 | .. _dataone.nodeToken.file:          |                                                                             |                               |
 |                                      |                                                                             |                               |
-| dataone.nodeToken.file               | The path to a file that contains a (JWT) token. This token will be used in  |                               |
-|                                      | the dataone-indexer to authorize access to private objects' system metadata.|                               |
-|                                      | A valid token consists of 3 parts delimited with a period. The first section|                               |
-|                                      | contains the header (and info about how the JWT was signed), the second     |                               |
-|                                      | includes information on the subject (ex. id, issuer, expiry date, etc.),    |                               |
-|                                      | and the last section is the signature                                       |                               |
+| dataone.nodeToken.file               | The path to a file that contains an authentication token. This token will be|                               |
+|                                      | used by the dataone-indexer, to enable indexing of private datasets.        |                               |
 |                                      |                                                                             |                               |
 |                                      | Default Value: /var/metacat/certs/token                                     |                               |
 +--------------------------------------+-----------------------------------------------------------------------------+-------------------------------+

--- a/docs/user/metacat/source/metacat-properties.rst
+++ b/docs/user/metacat/source/metacat-properties.rst
@@ -171,7 +171,17 @@ others are managed with the properties configuration utility.
 |                                      |                                                                             |                               |
 |                                      | Default Value: (empty: only cn is used for token verification)              |                               |
 +--------------------------------------+-----------------------------------------------------------------------------+-------------------------------+
-
+| .. _dataone.nodeToken.file:          |                                                                             |                               |
+|                                      |                                                                             |                               |
+| dataone.nodeToken.file               | The path to a file that contains a (JWT) token. This token will be used in  |                               |
+|                                      | the dataone-indexer to authorize access to private objects' system metadata.|                               |
+|                                      | A valid token consists of 3 parts delimited with a period. The first section|                               |
+|                                      | contains the header (and info about how the JWT was signed), the second     |                               |
+|                                      | includes information on the subject (ex. id, issuer, expiry date, etc.),    |                               |
+|                                      | and the last section is the signature                                       |                               |
+|                                      |                                                                             |                               |
+|                                      | Default Value: /var/metacat/certs/token                                     |                               |
++--------------------------------------+-----------------------------------------------------------------------------+-------------------------------+
 
 Solr Properties
 ----------------------

--- a/lib/admin/admin.css
+++ b/lib/admin/admin.css
@@ -238,6 +238,7 @@ input[type="text"] {
     margin-left: 10px;
     margin-top: 0.5em;
     display: inline-block;
+    float: left;
 }
 
 .icon-plus-sign {
@@ -274,6 +275,16 @@ input[type="text"] {
     float: left;
     margin-left: 1em;
     margin-bottom: 10px;
+}
+
+.new-badge {
+    background: green;
+    color: white;
+    margin-top: 3px;
+    border-radius: 10px;
+    padding: 2px 4px;
+    display: inline-block;
+    margin-left: 0 !important;
 }
 
 

--- a/lib/admin/admin.css
+++ b/lib/admin/admin.css
@@ -280,9 +280,8 @@ input[type="text"] {
 .new-badge {
     background: green;
     color: white;
-    margin-top: 3px;
     border-radius: 10px;
-    padding: 2px 4px;
+    padding: 0px 4px;
     display: inline-block;
     margin-left: 0 !important;
 }

--- a/lib/admin/properties-configuration.jsp
+++ b/lib/admin/properties-configuration.jsp
@@ -56,7 +56,6 @@
 			Map<Integer, MetaDataGroup> groupMap = metadata.getGroups();
 			Set<Integer> groupIdSet = groupMap.keySet();
 
-
 			for (Integer groupId : groupIdSet) {
 				// for this group, display the header (group name)
 				MetaDataGroup metaDataGroup = (MetaDataGroup)groupMap.get(groupId);
@@ -86,36 +85,36 @@
 					metadata.getPropertiesInGroup(metaDataGroup.getIndex());
 				Set<Integer> propertyIndexes = propertyMap.keySet();
 				// iterate through each property and display appropriately
-				for (Integer propertyIndex : propertyIndexes) {
-					MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
-	    			String fieldType = metaDataProperty.getFieldType(); 
-	    			if (fieldType.equals("select")) {
+					for (Integer propertyIndex : propertyIndexes) {
+						MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
+	    				String fieldType = metaDataProperty.getFieldType(); 
+	    				if (fieldType.equals("select")) {
 	%> 
-					<div class="form-row">
-	   				<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>"><%= metaDataProperty.getLabel() %></label></div>
-						<select class="textinput" name="<%= metaDataProperty.getKey() %>">
+							<div class="form-row">
+	   						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>"><%= metaDataProperty.getLabel() %></label></div>
+							<select class="textinput" name="<%= metaDataProperty.getKey() %>">
 	<%
-						Vector<String> fieldOptionValues = metaDataProperty.getFieldOptionValues();
-						Vector<String> fieldOptionNames = metaDataProperty.getFieldOptionNames();
-						for (int i = 0; i < fieldOptionNames.size(); i++) {
+							Vector<String> fieldOptionValues = metaDataProperty.getFieldOptionValues();
+							Vector<String> fieldOptionNames = metaDataProperty.getFieldOptionNames();
+							for (int i = 0; i < fieldOptionNames.size(); i++) {
 	%>
-						<option value="<%= fieldOptionValues.elementAt(i) %>"
+								<option value="<%= fieldOptionValues.elementAt(i) %>"
 	<%
-							if (fieldOptionValues.elementAt(i).equals(request.getAttribute(metaDataProperty.getKey()))) {
+								if (fieldOptionValues.elementAt(i).equals(request.getAttribute(metaDataProperty.getKey()))) {
 	%>
-								selected="yes"
+									selected="yes"
 	<%
-							}
+								}
 	%>
 						> <%= fieldOptionNames.elementAt(i) %>
 	<%
-					}
+							}
 	%>
-						</select>
+							</select>
 						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
 					</div>
 	<%		
-					} else if (fieldType.equals("password")) {
+						} else if (fieldType.equals("password")) {
 	%>
 					<div class="form-row">
 						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>" ><%= metaDataProperty.getLabel() %></label></div>
@@ -126,14 +125,14 @@
 						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
 					</div>
 	<%
-					} else if (fieldType.equals("hidden")) {
-						%>
+						} else if (fieldType.equals("hidden")) {
+	%>
 							<input id="<%= metaDataProperty.getKey() %>" 
 									name="<%= metaDataProperty.getKey() %>" 	             		    	    	           		    	             			
 			           		    	value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
 			           		    	type="<%= fieldType %>"/> 
-		<%
-					} else {
+	<%
+						} else {
 	%>
 					<div class="form-row">
 						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %> "><%= metaDataProperty.getLabel() %></label>	</div>					
@@ -144,23 +143,22 @@
 						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
 					</div>          		    
 	<%   			
-					}
+						}
 	    			
-	    			if (metaDataProperty.getDescription() != null && metaDataProperty.getDescription().trim().length() > 0 ) {
-	    			    if (!metaDataProperty.getDescription().contains("new-badge")) {
+	    				if (metaDataProperty.getDescription() != null && metaDataProperty.getDescription().trim().length() > 0 ) {
+	    			    	if (!metaDataProperty.getDescription().contains("new-badge")) {
 	%>
-						    <div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
+						    	<div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
 	<%
-						} else {
+							} else {
 	%>
-						    <div class="textinput-description">[<%= metaDataProperty.getDescription().replace(". &lt;", ".] &lt;") %></div>
+						    	<div class="textinput-description">[<%= metaDataProperty.getDescription().replace(". &lt;", ".] &lt;") %></div>
 	<%
-	                    }
-	    			}
-				}
+	                    	}
+	    				}
+					}
 				}
 			}
-				
 		}
 	%>
 	

--- a/lib/admin/properties-configuration.jsp
+++ b/lib/admin/properties-configuration.jsp
@@ -55,8 +55,8 @@
 			// each group describes a section of properties
 			Map<Integer, MetaDataGroup> groupMap = metadata.getGroups();
 			Set<Integer> groupIdSet = groupMap.keySet();
-	
-			
+
+
 			for (Integer groupId : groupIdSet) {
 				// for this group, display the header (group name)
 				MetaDataGroup metaDataGroup = (MetaDataGroup)groupMap.get(groupId);
@@ -142,23 +142,20 @@
 		    			        value="<%= request.getAttribute(metaDataProperty.getKey()) %>"	             		    	    	           		    	             			
 		           		    	type="<%= fieldType %> "/>
 						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
-    <%
-                        int propIndexNo = metaDataProperty.getIndex();
-						if (propIndexNo == 13 || propIndexNo == 14) {
-    %>
-                        <span class="new-badge">New</span>
-    <%
-						}
-    %>
 					</div>          		    
 	<%   			
 					}
 	    			
 	    			if (metaDataProperty.getDescription() != null && metaDataProperty.getDescription().trim().length() > 0 ) {
+	    			    if (!metaDataProperty.getDescription().contains("new-badge")) {
 	%>
-	
-						<div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
+						    <div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
 	<%
+						} else {
+	%>
+						    <div class="textinput-description">[<%= metaDataProperty.getDescription().replace(". &lt;", ".] &lt;") %></div>
+	<%
+	                    }
 	    			}
 				}
 				}

--- a/lib/admin/properties-configuration.jsp
+++ b/lib/admin/properties-configuration.jsp
@@ -152,7 +152,7 @@
 	<%
 							} else {
 	%>
-						    	<div class="textinput-description">[<%= metaDataProperty.getDescription().replace(". &lt;", ".] &lt;") %></div>
+						    	<div class="textinput-description"><%= metaDataProperty.getDescription() %></div>
 	<%
 	                    	}
 	    				}

--- a/lib/admin/properties-configuration.jsp
+++ b/lib/admin/properties-configuration.jsp
@@ -1,7 +1,7 @@
 <%@ page language="java" %>
 <%@ page import="java.util.Set,java.util.Map,java.util.Vector,edu.ucsb.nceas.utilities.PropertiesMetaData" %>
 <%@ page import="edu.ucsb.nceas.utilities.MetaDataGroup,edu.ucsb.nceas.utilities.MetaDataProperty" %>
-<% 
+<%
 /**
  *  '$RCSfile$'
  *    Copyright: 2008 Regents of the University of California and the
@@ -11,7 +11,7 @@
  *   '$Author$'
  *     '$Date$'
  * '$Revision$'
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -35,140 +35,140 @@
 <%@ include file="./head-section.jsp"%>
 </head>
 <body>
-<%@ include file="./header-section.jsp"%> 
+<%@ include file="./header-section.jsp"%>
 
 <div class="document">
-	<h2>Metacat Properties Configuration</h2>
-	
-	<p>Enter Metacat System properties here.  All Fields must be filled in before saving.
-	</p>
-	<br clear="right"/>
-	
-	<%@ include file="page-message-section.jsp"%>
-	
-	<form method="POST" name="configuration_form" action="<%= request.getContextPath() %>/admin" 
-	                                        onsubmit="return submitForm(this);">
-	<% 
-		// metadata holds all group and properties metadata
-	    PropertiesMetaData metadata = (PropertiesMetaData)request.getAttribute("metadata");
-		if (metadata != null) {
-			// each group describes a section of properties
-			Map<Integer, MetaDataGroup> groupMap = metadata.getGroups();
-			Set<Integer> groupIdSet = groupMap.keySet();
+    <h2>Metacat Properties Configuration</h2>
 
-			for (Integer groupId : groupIdSet) {
-				// for this group, display the header (group name)
-				MetaDataGroup metaDataGroup = (MetaDataGroup)groupMap.get(groupId);
-				if (groupId == 0) {
-					// get all the properties in this group
-					Map<Integer, MetaDataProperty> propertyMap = 
-						metadata.getPropertiesInGroup(metaDataGroup.getIndex());
-					Set<Integer> propertyIndexes = propertyMap.keySet();
-					// iterate through each property and display appropriately
-					for (Integer propertyIndex : propertyIndexes) {
-						MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
-		    			String fieldType = metaDataProperty.getFieldType(); 
-		    			if (fieldType.equals("hidden")) {
-	%>
-							<input type="hidden"
-	                               name="<%= metaDataProperty.getKey() %>" 	             		    	    	           		    	             			
-		           		    	   value="<%= request.getAttribute(metaDataProperty.getKey()) %>"/>
-	<%
-		    			}
-					}
-				} else {		
-	%>
-			<h3><%= metaDataGroup.getName()  %></h3>
-	<%
-				// get all the properties in this group
-				Map<Integer, MetaDataProperty> propertyMap = 
-					metadata.getPropertiesInGroup(metaDataGroup.getIndex());
-				Set<Integer> propertyIndexes = propertyMap.keySet();
-				// iterate through each property and display appropriately
-					for (Integer propertyIndex : propertyIndexes) {
-						MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
-	    				String fieldType = metaDataProperty.getFieldType(); 
-	    				if (fieldType.equals("select")) {
-	%> 
-							<div class="form-row">
-	   						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>"><%= metaDataProperty.getLabel() %></label></div>
-							<select class="textinput" name="<%= metaDataProperty.getKey() %>">
-	<%
-							Vector<String> fieldOptionValues = metaDataProperty.getFieldOptionValues();
-							Vector<String> fieldOptionNames = metaDataProperty.getFieldOptionNames();
-							for (int i = 0; i < fieldOptionNames.size(); i++) {
-	%>
-								<option value="<%= fieldOptionValues.elementAt(i) %>"
-	<%
-								if (fieldOptionValues.elementAt(i).equals(request.getAttribute(metaDataProperty.getKey()))) {
-	%>
-									selected="yes"
-	<%
-								}
-	%>
-						> <%= fieldOptionNames.elementAt(i) %>
-	<%
-							}
-	%>
-							</select>
-						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
-					</div>
-	<%		
-						} else if (fieldType.equals("password")) {
-	%>
-					<div class="form-row">
-						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>" ><%= metaDataProperty.getLabel() %></label></div>
-						<input class="textinput" id="<%= metaDataProperty.getKey() %>" 
-								name="<%= metaDataProperty.getKey() %>" 	             		    	    	           		    	             			
-		           		    	value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
-		           		    	type="<%= fieldType %>"/> 
-						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
-					</div>
-	<%
-						} else if (fieldType.equals("hidden")) {
-	%>
-							<input id="<%= metaDataProperty.getKey() %>" 
-									name="<%= metaDataProperty.getKey() %>" 	             		    	    	           		    	             			
-			           		    	value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
-			           		    	type="<%= fieldType %>"/> 
-	<%
-						} else {
-	%>
-					<div class="form-row">
-						<div class="textinput-label"><label for="<%= metaDataProperty.getKey() %> "><%= metaDataProperty.getLabel() %></label>	</div>					
-						<input class="textinput" id="<%= metaDataProperty.getKey() %>" 
-								name="<%= metaDataProperty.getKey() %>" 
-		    			        value="<%= request.getAttribute(metaDataProperty.getKey()) %>"	             		    	    	           		    	             			
-		           		    	type="<%= fieldType %> "/>
-						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
-					</div>          		    
-	<%   			
-						}
-	    			
-	    				if (metaDataProperty.getDescription() != null && metaDataProperty.getDescription().trim().length() > 0 ) {
-	    			    	if (!metaDataProperty.getDescription().contains("new-badge")) {
-	%>
-						    	<div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
-	<%
-							} else {
-	%>
-						    	<div class="textinput-description"><%= metaDataProperty.getDescription() %></div>
-	<%
-	                    	}
-	    				}
-					}
-				}
-			}
-		}
-	%>
-	
-				<input type="hidden" name="configureType" value="properties"/>
-				<input type="hidden" name="processForm" value="true"/>
-				<input class=button type="submit" value="Save"/>
-				<input class=button type="button" value="Cancel" onClick="forward('./admin')"> 
-	
-	</form>
-	
+    <p>Enter Metacat System properties here.  All Fields must be filled in before saving.
+    </p>
+    <br clear="right"/>
+
+    <%@ include file="page-message-section.jsp"%>
+
+    <form method="POST" name="configuration_form" action="<%= request.getContextPath() %>/admin"
+                                            onsubmit="return submitForm(this);">
+    <%
+        // metadata holds all group and properties metadata
+        PropertiesMetaData metadata = (PropertiesMetaData)request.getAttribute("metadata");
+        if (metadata != null) {
+            // each group describes a section of properties
+            Map<Integer, MetaDataGroup> groupMap = metadata.getGroups();
+            Set<Integer> groupIdSet = groupMap.keySet();
+
+            for (Integer groupId : groupIdSet) {
+                // for this group, display the header (group name)
+                MetaDataGroup metaDataGroup = (MetaDataGroup)groupMap.get(groupId);
+                if (groupId == 0) {
+                    // get all the properties in this group
+                    Map<Integer, MetaDataProperty> propertyMap =
+                        metadata.getPropertiesInGroup(metaDataGroup.getIndex());
+                    Set<Integer> propertyIndexes = propertyMap.keySet();
+                    // iterate through each property and display appropriately
+                    for (Integer propertyIndex : propertyIndexes) {
+                        MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
+                        String fieldType = metaDataProperty.getFieldType();
+                        if (fieldType.equals("hidden")) {
+    %>
+                            <input type="hidden"
+                                   name="<%= metaDataProperty.getKey() %>"
+                                    value="<%= request.getAttribute(metaDataProperty.getKey()) %>"/>
+    <%
+                        }
+                    }
+                } else {
+    %>
+            <h3><%= metaDataGroup.getName()  %></h3>
+    <%
+                // get all the properties in this group
+                Map<Integer, MetaDataProperty> propertyMap =
+                    metadata.getPropertiesInGroup(metaDataGroup.getIndex());
+                Set<Integer> propertyIndexes = propertyMap.keySet();
+                // iterate through each property and display appropriately
+                    for (Integer propertyIndex : propertyIndexes) {
+                        MetaDataProperty metaDataProperty = propertyMap.get(propertyIndex);
+                        String fieldType = metaDataProperty.getFieldType();
+                        if (fieldType.equals("select")) {
+    %>
+                            <div class="form-row">
+                            <div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>"><%= metaDataProperty.getLabel() %></label></div>
+                            <select class="textinput" name="<%= metaDataProperty.getKey() %>">
+    <%
+                            Vector<String> fieldOptionValues = metaDataProperty.getFieldOptionValues();
+                            Vector<String> fieldOptionNames = metaDataProperty.getFieldOptionNames();
+                            for (int i = 0; i < fieldOptionNames.size(); i++) {
+    %>
+                                <option value="<%= fieldOptionValues.elementAt(i) %>"
+    <%
+                                if (fieldOptionValues.elementAt(i).equals(request.getAttribute(metaDataProperty.getKey()))) {
+    %>
+                                    selected="yes"
+    <%
+                                }
+    %>
+                        > <%= fieldOptionNames.elementAt(i) %>
+    <%
+                            }
+    %>
+                            </select>
+                        <i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
+                    </div>
+    <%
+                        } else if (fieldType.equals("password")) {
+    %>
+                    <div class="form-row">
+                        <div class="textinput-label"><label for="<%= metaDataProperty.getKey() %>" ><%= metaDataProperty.getLabel() %></label></div>
+                        <input class="textinput" id="<%= metaDataProperty.getKey() %>"
+                                name="<%= metaDataProperty.getKey() %>"
+                                value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
+                                type="<%= fieldType %>"/>
+                        <i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
+                    </div>
+    <%
+                        } else if (fieldType.equals("hidden")) {
+    %>
+                            <input id="<%= metaDataProperty.getKey() %>"
+                                    name="<%= metaDataProperty.getKey() %>"
+                                    value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
+                                    type="<%= fieldType %>"/>
+    <%
+                        } else {
+    %>
+                    <div class="form-row">
+                        <div class="textinput-label"><label for="<%= metaDataProperty.getKey() %> "><%= metaDataProperty.getLabel() %></label>    </div>
+                        <input class="textinput" id="<%= metaDataProperty.getKey() %>"
+                                name="<%= metaDataProperty.getKey() %>"
+                                value="<%= request.getAttribute(metaDataProperty.getKey()) %>"
+                                type="<%= fieldType %> "/>
+                        <i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
+                    </div>
+    <%
+                        }
+
+                        if (metaDataProperty.getDescription() != null && metaDataProperty.getDescription().trim().length() > 0 ) {
+                            if (!metaDataProperty.getDescription().contains("new-badge")) {
+    %>
+                                <div class="textinput-description">[<%= metaDataProperty.getDescription() %>]</div>
+    <%
+                            } else {
+    %>
+                                <div class="textinput-description"><%= metaDataProperty.getDescription() %></div>
+    <%
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    %>
+
+                <input type="hidden" name="configureType" value="properties"/>
+                <input type="hidden" name="processForm" value="true"/>
+                <input class=button type="submit" value="Save"/>
+                <input class=button type="button" value="Cancel" onClick="forward('./admin')">
+
+    </form>
+
 </div>
 <%@ include file="./footer-section.jsp"%>
 

--- a/lib/admin/properties-configuration.jsp
+++ b/lib/admin/properties-configuration.jsp
@@ -140,8 +140,16 @@
 						<input class="textinput" id="<%= metaDataProperty.getKey() %>" 
 								name="<%= metaDataProperty.getKey() %>" 
 		    			        value="<%= request.getAttribute(metaDataProperty.getKey()) %>"	             		    	    	           		    	             			
-		           		    	type="<%= fieldType %> "/>	
+		           		    	type="<%= fieldType %> "/>
 						<i class="icon-question-sign" onClick="helpWindow('<%= request.getContextPath() %>','<%= metaDataProperty.getHelpFile() %>')"></i>
+    <%
+                        int propIndexNo = metaDataProperty.getIndex();
+						if (propIndexNo == 13 || propIndexNo == 14) {
+    %>
+                        <span class="new-badge">New</span>
+    <%
+						}
+    %>
 					</div>          		    
 	<%   			
 					}

--- a/lib/metacat.properties.metadata.xml
+++ b/lib/metacat.properties.metadata.xml
@@ -411,7 +411,7 @@
             &#91;The path to the admin jwt token that will be used in dataone-indexer to access the
             private objects' system metadata.&#93; &lt;span class="new-badge"&gt;New&lt;/span&gt;
         </description>
-        <helpFile>docs/metacat-properties.html/#admin-token</helpFile>
+        <helpFile>docs/metacat-properties.html#dataone-nodetoken-file</helpFile>
     </config>
 
     <!-- handler plugin -->

--- a/lib/metacat.properties.metadata.xml
+++ b/lib/metacat.properties.metadata.xml
@@ -402,6 +402,18 @@
         <helpFile>docs/metacat-properties.html#cn-server-publiccert-filename</helpFile>
     </config>
 
+    <config>
+        <key>dataone.nodeToken.file</key>
+        <label>Admin Token Path</label>
+        <group>4</group>
+        <index>14</index>
+        <description>
+            The path to the admin jwt token that will be used in dataone-indexer to access the
+            private objects' system metadata.
+        </description>
+        <helpFile>docs/metacat-properties.html</helpFile>
+    </config>
+
     <!-- handler plugin -->
     <config>
         <key>plugin.handlers</key>

--- a/lib/metacat.properties.metadata.xml
+++ b/lib/metacat.properties.metadata.xml
@@ -395,9 +395,9 @@
         <group>4</group>
         <index>13</index>
         <description>
-            Semicolon-separated list of paths to certificate files, containing public keys to be
+            &#91;Semicolon-separated list of paths to certificate files, containing public keys to be
             used by d1_portal to verify incoming request jwt tokens (in addition to verifying
-            against the CN server). &lt;span class="new-badge"&gt;New&lt;/span&gt;
+            against the CN server).&#93; &lt;span class="new-badge"&gt;New&lt;/span&gt;
         </description>
         <helpFile>docs/metacat-properties.html#cn-server-publiccert-filename</helpFile>
     </config>
@@ -408,8 +408,8 @@
         <group>4</group>
         <index>14</index>
         <description>
-            The path to the admin jwt token that will be used in dataone-indexer to access the
-            private objects' system metadata. &lt;span class="new-badge"&gt;New&lt;/span&gt;
+            &#91;The path to the admin jwt token that will be used in dataone-indexer to access the
+            private objects' system metadata.&#93; &lt;span class="new-badge"&gt;New&lt;/span&gt;
         </description>
         <helpFile>docs/metacat-properties.html/#admin-token</helpFile>
     </config>

--- a/lib/metacat.properties.metadata.xml
+++ b/lib/metacat.properties.metadata.xml
@@ -411,7 +411,7 @@
             The path to the admin jwt token that will be used in dataone-indexer to access the
             private objects' system metadata.
         </description>
-        <helpFile>docs/metacat-properties.html</helpFile>
+        <helpFile>docs/metacat-properties.html/#admin-token</helpFile>
     </config>
 
     <!-- handler plugin -->

--- a/lib/metacat.properties.metadata.xml
+++ b/lib/metacat.properties.metadata.xml
@@ -397,7 +397,7 @@
         <description>
             Semicolon-separated list of paths to certificate files, containing public keys to be
             used by d1_portal to verify incoming request jwt tokens (in addition to verifying
-            against the CN server).
+            against the CN server). &lt;span class="new-badge"&gt;New&lt;/span&gt;
         </description>
         <helpFile>docs/metacat-properties.html#cn-server-publiccert-filename</helpFile>
     </config>
@@ -409,7 +409,7 @@
         <index>14</index>
         <description>
             The path to the admin jwt token that will be used in dataone-indexer to access the
-            private objects' system metadata.
+            private objects' system metadata. &lt;span class="new-badge"&gt;New&lt;/span&gt;
         </description>
         <helpFile>docs/metacat-properties.html/#admin-token</helpFile>
     </config>


### PR DESCRIPTION
Hi @taojing2002, can you please help review my PR for `Feature-1804`? As discussed, we have now moved the `new` indicator/badge to the `helpDescription` field in the `metacat.properties.metadata.xml` as it is a bit involved (and not necessary) to revise other classes to dynamically add this badge to a config item.

Moving forward, to add a `new` indicator - we will manually add description text that follows this format:
- `&#91;This is an example sentence.&#93; &lt;span class="new-badge"&gt;New&lt;/span&gt;`

In `properties-configuration.jsp`, I have amended the JSP code to not include left-right square brackets when it finds `new-badge` in the description.

**Example/Screenshot:**
<img width="665" alt="image" src="https://github.com/NCEAS/metacat/assets/12792837/7550b73f-298f-44da-bf4a-75118d40df5f">
