### PR TITLE
Feature-1816: Metacat Admin MN Privileges (auth.administrators)

### DIFF
--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
+import edu.ucsb.nceas.metacat.shared.MetacatUtilException;
+import edu.ucsb.nceas.metacat.util.AuthUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.commons.logging.Log;
@@ -358,6 +360,21 @@ public class D1AuthHelper {
             }
         } catch (ServiceFailure e) {
             exceptions.add(e);
+        }
+
+        // If subject is not a LocalNodeAdmin or CNAdmin, check to see if subject is a
+        // Metacat admin (auth.administrators) - who also have admin privileges like the above
+        try {
+            String adminUser = session.getSubject().getValue();
+            if (adminUser != null) {
+                logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + adminUser + " for Metacat admin privileges.");
+                if (AuthUtil.isAdministrator(adminUser, null)) {
+                    return;
+                }
+            }
+        } catch (MetacatUtilException mue) {
+            ServiceFailure sf = new ServiceFailure("0000", mue.getMessage());
+            exceptions.add(sf);
         }
 
         if (exceptions.isEmpty()) { 

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -367,7 +367,8 @@ public class D1AuthHelper {
         try {
             String adminUser = session.getSubject().getValue();
             if (adminUser != null) {
-                logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + adminUser + " for Metacat admin privileges.");
+                logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + adminUser +
+                                     " for Metacat admin privileges.");
                 if (AuthUtil.isAdministrator(adminUser, null)) {
                     return;
                 }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -251,14 +251,13 @@ public class D1AuthHelperTest {
         fail("Not yet implemented");
     }
 
-    @Test
-    public void testPrepareAndThrowNotAuthorized() {
-        try {
-            authDel.prepareAndThrowNotAuthorized(session, TypeFactory.buildIdentifier("dip"), Permission.READ, "3456dc");
-        } catch (NotAuthorized e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+    /**
+     * Confirm that prepareAndThrowNotAuthorized throws NotAuthorized exception with invalid session
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testPrepareAndThrowNotAuthorized() throws Exception {
+        authDel.prepareAndThrowNotAuthorized(
+            session, TypeFactory.buildIdentifier("dip"), Permission.READ, "3456dc");
     }
 
     @Ignore("requires client communication...")

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -161,10 +161,31 @@ public class D1AuthHelperTest {
         fail("Not yet implemented");
     }
 
-    @Ignore("Not yet implemented...")
+    /**
+     * Confirm that doUpdateAuth does not throw exception with approved 'authoritativeMemberNode'
+     * value on sysmeta object.
+     */
     @Test
-    public void testDoUpdateAuth() {
-        fail("Not yet implemented");
+    public void testDoUpdateAuth() throws Exception {
+        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
+            TypeFactory.buildIdentifier("dip"),
+            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
+            "MD5",
+            TypeFactory.buildFormatIdentifier("text/csv"),
+            TypeFactory.buildSubject("submitterRightsHolder"));
+        AccessPolicy ap = new AccessPolicy();
+        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
+        sysmeta.setAccessPolicy(ap);
+        sysmeta.setAuthoritativeMemberNode(TypeFactory.buildNodeReference(
+            "urn:node:unitTestAuthMN"));
+
+        try {
+            authDelMock.doUpdateAuth(session, sysmeta, Permission.CHANGE_PERMISSION,
+                                     TypeFactory.buildNodeReference(
+                "urn:node:unitTestAuthMN"));
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -246,10 +246,17 @@ public class D1AuthHelperTest {
         fail("Not yet implemented");
     }
 
-    @Ignore("requires Metacat configuration...")
+    /**
+     * Confirm that isLocalNodeAdmin returns true with valid NodeAdmin subject
+     */
     @Test
     public void testIsLocalNodeAdmin() throws ServiceFailure {
-        authDel.isLocalNodeAdmin(cn1CNSession, NodeType.CN);
+        Session sessionLocalNodeAdmin = new Session();
+        sessionLocalNodeAdmin.setSubject(
+            TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
+
+        boolean isLocalCnNodeAdmin = authDel.isLocalNodeAdmin(sessionLocalNodeAdmin, null);
+        assertTrue(isLocalCnNodeAdmin);
     }
 
     @Test

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -3,13 +3,10 @@ package edu.ucsb.nceas.metacat.dataone;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dataone.service.exceptions.NotAuthorized;
-import org.dataone.service.exceptions.NotFound;
 import org.dataone.service.exceptions.ServiceFailure;
 import org.dataone.service.types.v1.AccessPolicy;
 import org.dataone.service.types.v1.NodeType;
@@ -38,7 +35,7 @@ public class D1AuthHelperTest {
     static NodeList nl;
 
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    public static void setUpBeforeClass() {
         nl = new NodeList();
         Node cn1 = new Node();
         cn1.setType(NodeType.CN);
@@ -285,7 +282,7 @@ public class D1AuthHelperTest {
      * Confirm doGetSysmetaAuthorization does not throw exception with authorized subject
      */
     @Test
-    public void testDoGetSysmetaAuthorization() throws Exception {
+    public void testDoGetSysmetaAuthorization() {
         try {
             authDel.doGetSysmetaAuthorization(session, sysmeta, Permission.WRITE);
         } catch (Exception e) {
@@ -298,7 +295,7 @@ public class D1AuthHelperTest {
      * Confirm that isAuthorizedBySysMetaSubjects returns true with valid sysmeta subject
      */
     @Test
-    public void testIsAuthorizedBySysMetaSubjects() throws Exception {
+    public void testIsAuthorizedBySysMetaSubjects() {
         boolean isAuthBySysmetaSubjects =
             authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
         assertTrue(isAuthBySysmetaSubjects);

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -95,8 +95,6 @@ public class D1AuthHelperTest {
 
     /**
      * Get a minimal SystemMetadata object with default values
-     *
-     * @return
      */
     private SystemMetadata getGenericSysmetaObject() throws Exception {
         SystemMetadata sysmeta =
@@ -164,6 +162,7 @@ public class D1AuthHelperTest {
 
     }
 
+    // TODO: This test should be implemented when time permitting.
     @Ignore("Not yet implemented...")
     @Test
     public void testExpandRightsHolder() {

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -157,22 +157,9 @@ public class D1AuthHelperTest {
 
     @Ignore("requires client communication...")
     @Test
-    public void testDoIsAuthorized() {
-        fail("Not yet implemented");
-    }
-
-    @Ignore("requires client communication...")
-    @Test
-    public void testDoAuthoritativeMNAuthorization() {
-        fail("Not yet implemented");
-    }
-
-    @Ignore("requires client communication...")
-    @Test
     public void testDoUpdateAuth() {
         fail("Not yet implemented");
     }
-
 
     /**
      * Confirm that 'doCNOnlyAuthorization' does not throw exception with good subject

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -245,12 +245,6 @@ public class D1AuthHelperTest {
         authDelMock.doAdminAuthorization(session);
     }
 
-    @Ignore("requires client communication...")
-    @Test
-    public void testDoGetSysmetaAuthorization() {
-        fail("Not yet implemented");
-    }
-
     /**
      * Confirm that prepareAndThrowNotAuthorized throws NotAuthorized exception with invalid session
      */
@@ -277,6 +271,29 @@ public class D1AuthHelperTest {
 
         boolean isLocalCnNodeAdmin = authDel.isLocalNodeAdmin(sessionLocalNodeAdmin, null);
         assertTrue(isLocalCnNodeAdmin);
+    }
+
+    /**
+     * Confirm doGetSysmetaAuthorization does not throw exception with authorized subject
+     */
+    @Test
+    public void testDoGetSysmetaAuthorization() throws Exception {
+        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
+            TypeFactory.buildIdentifier("dip"),
+            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
+            "MD5",
+            TypeFactory.buildFormatIdentifier("text/csv"),
+            TypeFactory.buildSubject("submitterRightsHolder"));
+        AccessPolicy ap = new AccessPolicy();
+        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
+        sysmeta.setAccessPolicy(ap);
+
+        try {
+            authDel.doGetSysmetaAuthorization(session, sysmeta, Permission.WRITE);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -67,7 +67,7 @@ public class D1AuthHelperTest {
         
         Node authMN = new Node();
         authMN.setType(NodeType.MN);
-        authMN.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestauthMN"));
+        authMN.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
                
         List<Subject> sublist4 = new ArrayList<>();
         sublist4.add(TypeFactory.buildSubject("authMNSubject"));
@@ -299,9 +299,30 @@ public class D1AuthHelperTest {
         authDel.isReplicaMNodeAdmin(session, sysmeta, nl);
     }
 
+    /**
+     * Confirm isAuthoritativeMNodeAdmin returns true with correct session subject
+     */
     @Test
-    public void testIsAuthoritativeMNodeAdmin() {
-        authDel.isAuthoritativeMNodeAdmin(session, TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"), nl);
+    public void testIsAuthoritativeMNodeAdmin_validMnSubject() {
+        Session sessionAuthMNSubject = new Session();
+        sessionAuthMNSubject.setSubject(TypeFactory.buildSubject("authMNSubject"));
+        boolean isAuthMNNodeAdmin = authDel.isAuthoritativeMNodeAdmin(sessionAuthMNSubject,
+                                                                      TypeFactory.buildNodeReference(
+                                                                          "urn:node:unitTestAuthMN"),
+                                                                      nl);
+        assertTrue(isAuthMNNodeAdmin);
+    }
+
+    /**
+     * Confirm isAuthoritativeMNodeAdmin returns false with incorrect session subject
+     */
+    @Test
+    public void testIsAuthoritativeMNodeAdmin_invalidMnSubject() {
+        boolean isAuthMNNodeAdmin = authDel.isAuthoritativeMNodeAdmin(session,
+                                                                      TypeFactory.buildNodeReference(
+                                                                          "urn:node:unitTestAuthMN"),
+                                                                      nl);
+        assertFalse(isAuthMNNodeAdmin);
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -31,9 +31,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import edu.ucsb.nceas.LeanTestUtils;
-import edu.ucsb.nceas.metacat.util.AuthUtil;
-import edu.ucsb.nceas.metacat.properties.PropertiesWrapper;
-import org.mockito.Mockito;
 
 public class D1AuthHelperTest {
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -175,41 +175,42 @@ public class D1AuthHelperTest {
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' accepts Metacat auth.administrator
+     * Confirm that 'doAdminAuthorization' accepts a Metacat auth.administrator
      */
     @Test
     public void testDoAdminAuthorization_metacatAdmin() throws Exception {
-        Session sessionTwo = new Session();
-        sessionTwo.setSubject(TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+        Session sessionMetacatAdmin = new Session();
+        sessionMetacatAdmin.setSubject(TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
 
-        authDel.doAdminAuthorization(sessionTwo);
+        authDel.doAdminAuthorization(sessionMetacatAdmin);
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' accepts correct cnAdmin
+     * Confirm that 'doAdminAuthorization' accepts cnAdmin
      */
     @Test
     public void testDoAdminAuthorization_cnAdmin() throws Exception {
-        Session sessionTwo = new Session();
-        sessionTwo.setSubject(TypeFactory.buildSubject("CN=urn:node:CN,DC=dataone,DC=org"));
+        Session sessionCnAdmin = new Session();
+        sessionCnAdmin.setSubject(TypeFactory.buildSubject("CN=urn:node:CN,DC=dataone,DC=org"));
 
-        authDel.doAdminAuthorization(sessionTwo);
+        authDel.doAdminAuthorization(sessionCnAdmin);
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' accepts correct localNodeAdmin
+     * Confirm that 'doAdminAuthorization' accepts localNodeAdmin
      */
     @Test
     public void testDoAdminAuthorization_localNodeAdmin() throws Exception {
-        Session sessionThree = new Session();
-        sessionThree.setSubject(TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
+        Session sessionLocalNodeAdmin = new Session();
+        sessionLocalNodeAdmin.setSubject(TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
 
-        authDel.doAdminAuthorization(sessionThree);
+        authDel.doAdminAuthorization(sessionLocalNodeAdmin);
     }
 
 
     /**
-     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with unauthorized
+     * subject.
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_notAuthorized() throws Exception {

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -306,7 +306,8 @@ public class D1AuthHelperTest {
 
     @Test
     public void testIsCNAdmin() {
-        authDel.isCNAdmin(cn1CNSession, nl);
+        boolean isCNAdmin = authDel.isCNAdmin(cn1CNSession, nl);
+        assertTrue(isCNAdmin);
     }
 
     @Test

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -93,6 +93,26 @@ public class D1AuthHelperTest {
     Session cn1CNSession;
     SystemMetadata sysmeta;
 
+    /**
+     * Get a minimal SystemMetadata object with default values
+     *
+     * @return
+     */
+    private SystemMetadata getGenericSysmetaObject() throws Exception {
+        SystemMetadata sysmeta =
+            TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
+                                                   new ByteArrayInputStream(
+                                                       ("tra la la la la").getBytes("UTF-8")),
+                                                   "MD5",
+                                                   TypeFactory.buildFormatIdentifier("text/csv"),
+                                                   TypeFactory.buildSubject(
+                                                       "submitterRightsHolder"));
+        AccessPolicy ap = new AccessPolicy();
+        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
+        sysmeta.setAccessPolicy(ap);
+        return sysmeta;
+    }
+
     @Before
     public void setUp() throws Exception {
 
@@ -103,15 +123,8 @@ public class D1AuthHelperTest {
         authDelMock = Mockito.spy(authDel);
         Mockito.doReturn(nl).when(authDelMock).getCNNodeList();
 
-        //build a SystemMetadata object
-        sysmeta = TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
-                                                         new ByteArrayInputStream(
-                                                             ("tra la la la la").getBytes("UTF-8")),
-                                                         "MD5", TypeFactory.buildFormatIdentifier(
-                "text/csv"), TypeFactory.buildSubject("submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
+        // Build/get a SystemMetadata object
+        sysmeta = getGenericSysmetaObject();
 
         Replica replicaA = new Replica();
         replicaA.setReplicaMemberNode(TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
@@ -151,26 +164,6 @@ public class D1AuthHelperTest {
 
     }
 
-    /**
-     * Get a minimal SystemMetadata object with default values
-     *
-     * @return
-     */
-    private SystemMetadata getGenericSysmetaObject() throws Exception {
-        SystemMetadata sysmeta =
-            TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
-                                                   new ByteArrayInputStream(
-                                                       ("tra la la la la").getBytes("UTF-8")),
-                                                   "MD5",
-                                                   TypeFactory.buildFormatIdentifier("text/csv"),
-                                                   TypeFactory.buildSubject(
-                                                       "submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
-        return sysmeta;
-    }
-
     @Ignore("Not yet implemented...")
     @Test
     public void testExpandRightsHolder() {
@@ -183,12 +176,12 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testDoUpdateAuth() throws Exception {
-        SystemMetadata sysmeta = getGenericSysmetaObject();
-        sysmeta.setAuthoritativeMemberNode(
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
             TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
 
         try {
-            authDelMock.doUpdateAuth(session, sysmeta, Permission.CHANGE_PERMISSION,
+            authDelMock.doUpdateAuth(session, sysmetaEdited, Permission.CHANGE_PERMISSION,
                                      TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
         } catch (Exception e) {
             fail(e.getMessage());
@@ -294,8 +287,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testDoGetSysmetaAuthorization() throws Exception {
-        SystemMetadata sysmeta = getGenericSysmetaObject();
-
         try {
             authDel.doGetSysmetaAuthorization(session, sysmeta, Permission.WRITE);
         } catch (Exception e) {
@@ -309,8 +300,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testIsAuthorizedBySysMetaSubjects() throws Exception {
-        SystemMetadata sysmeta = getGenericSysmetaObject();
-
         boolean isAuthBySysmetaSubjects =
             authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
         assertTrue(isAuthBySysmetaSubjects);

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 public class D1AuthHelperTest {
 
     static NodeList nl;
-    
+
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         nl = new NodeList();
@@ -47,7 +47,7 @@ public class D1AuthHelperTest {
         sublist.add(TypeFactory.buildSubject("cn1Subject"));
         cn1.setSubjectList(sublist);
         nl.addNode(cn1);
-        
+
         Node cn2 = new Node();
         cn2.setType(NodeType.CN);
         cn2.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestCN2"));
@@ -55,29 +55,29 @@ public class D1AuthHelperTest {
         sublist2.add(TypeFactory.buildSubject("cn2Subject"));
         cn2.setSubjectList(sublist2);
         nl.addNode(cn2);
-        
+
         Node replMN = new Node();
         replMN.setType(NodeType.MN);
         replMN.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestReplMN"));
-       
+
         List<Subject> sublist3 = new ArrayList<>();
         sublist3.add(TypeFactory.buildSubject("replMNSubject"));
         replMN.setSubjectList(sublist3);
         nl.addNode(replMN);
-        
+
         Node authMN = new Node();
         authMN.setType(NodeType.MN);
         authMN.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
-               
+
         List<Subject> sublist4 = new ArrayList<>();
         sublist4.add(TypeFactory.buildSubject("authMNSubject"));
         authMN.setSubjectList(sublist4);
         nl.addNode(authMN);
-        
+
         Node otherMN = new Node();
         otherMN.setType(NodeType.MN);
         otherMN.setIdentifier(TypeFactory.buildNodeReference("urn:node:unitTestOtherMN"));
-               
+
         List<Subject> sublist5 = new ArrayList<>();
         sublist5.add(TypeFactory.buildSubject("otherMNSubject"));
         otherMN.setSubjectList(sublist5);
@@ -92,42 +92,39 @@ public class D1AuthHelperTest {
     Session replMNSession;
     Session cn1CNSession;
     SystemMetadata sysmeta;
-    
+
     @Before
     public void setUp() throws Exception {
 
         LeanTestUtils.initializePropertyService(LeanTestUtils.PropertiesMode.UNIT_TEST);
-        
-        authDel = new D1AuthHelper(null,TypeFactory.buildIdentifier("foo"),"1234NA","5678SF");
+
+        authDel = new D1AuthHelper(null, TypeFactory.buildIdentifier("foo"), "1234NA", "5678SF");
         // Create a D1AuthHelper mock for tests that make network calls (ex. getCNNodeList)
         authDelMock = Mockito.spy(authDel);
         Mockito.doReturn(nl).when(authDelMock).getCNNodeList();
-        
+
         //build a SystemMetadata object
-        sysmeta = TypeFactory.buildMinimalSystemMetadata(
-                TypeFactory.buildIdentifier("dip"), 
-                new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")), 
-                "MD5", 
-                TypeFactory.buildFormatIdentifier("text/csv"), 
-                TypeFactory.buildSubject("submitterRightsHolder"));
+        sysmeta = TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
+                                                         new ByteArrayInputStream(
+                                                             ("tra la la la la").getBytes("UTF-8")),
+                                                         "MD5", TypeFactory.buildFormatIdentifier(
+                "text/csv"), TypeFactory.buildSubject("submitterRightsHolder"));
         AccessPolicy ap = new AccessPolicy();
         ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
         sysmeta.setAccessPolicy(ap);
-        
-        
+
         Replica replicaA = new Replica();
         replicaA.setReplicaMemberNode(TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
-        replicaA.setReplicationStatus(ReplicationStatus.COMPLETED);       
-        
+        replicaA.setReplicationStatus(ReplicationStatus.COMPLETED);
+
         Replica replicaR = new Replica();
         replicaR.setReplicaMemberNode(TypeFactory.buildNodeReference("urn:node:unitTestReplMN"));
         replicaR.setReplicationStatus(ReplicationStatus.COMPLETED);
 
         sysmeta.addReplica(replicaA);
         sysmeta.addReplica(replicaR);
-        
 
-        
+
         // build a matching Session
         session = new Session();
         session.setSubject(TypeFactory.buildSubject("principal_subject"));
@@ -138,7 +135,7 @@ public class D1AuthHelperTest {
         p1.addEquivalentIdentity(TypeFactory.buildSubject("eq2"));
         subjectInfo.addPerson(p1);
         session.setSubjectInfo(subjectInfo);
-        
+
 
         authMNSession = new Session();
         authMNSession.setSubject(TypeFactory.buildSubject("authMNSubject"));
@@ -148,24 +145,26 @@ public class D1AuthHelperTest {
 
         otherMNSession = new Session();
         otherMNSession.setSubject(TypeFactory.buildSubject("otherMNSubject"));
-        
+
         cn1CNSession = new Session();
         cn1CNSession.setSubject(TypeFactory.buildSubject("cn1Subject"));
 
-        
     }
 
     /**
      * Get a minimal SystemMetadata object with default values
+     *
      * @return
      */
     private SystemMetadata getGenericSysmetaObject() throws Exception {
-        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
-            TypeFactory.buildIdentifier("dip"),
-            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
-            "MD5",
-            TypeFactory.buildFormatIdentifier("text/csv"),
-            TypeFactory.buildSubject("submitterRightsHolder"));
+        SystemMetadata sysmeta =
+            TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
+                                                   new ByteArrayInputStream(
+                                                       ("tra la la la la").getBytes("UTF-8")),
+                                                   "MD5",
+                                                   TypeFactory.buildFormatIdentifier("text/csv"),
+                                                   TypeFactory.buildSubject(
+                                                       "submitterRightsHolder"));
         AccessPolicy ap = new AccessPolicy();
         ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
         sysmeta.setAccessPolicy(ap);
@@ -185,13 +184,12 @@ public class D1AuthHelperTest {
     @Test
     public void testDoUpdateAuth() throws Exception {
         SystemMetadata sysmeta = getGenericSysmetaObject();
-        sysmeta.setAuthoritativeMemberNode(TypeFactory.buildNodeReference(
-            "urn:node:unitTestAuthMN"));
+        sysmeta.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
 
         try {
             authDelMock.doUpdateAuth(session, sysmeta, Permission.CHANGE_PERMISSION,
-                                     TypeFactory.buildNodeReference(
-                "urn:node:unitTestAuthMN"));
+                                     TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
         } catch (Exception e) {
             fail(e.getMessage());
         }
@@ -269,7 +267,8 @@ public class D1AuthHelperTest {
     }
 
     /**
-     * Confirm that prepareAndThrowNotAuthorized throws NotAuthorized exception with invalid session
+     * Confirm that prepareAndThrowNotAuthorized throws NotAuthorized exception with invalid
+     * session
      */
     @Test(expected = NotAuthorized.class)
     public void testPrepareAndThrowNotAuthorized() throws Exception {
@@ -312,7 +311,8 @@ public class D1AuthHelperTest {
     public void testIsAuthorizedBySysMetaSubjects() throws Exception {
         SystemMetadata sysmeta = getGenericSysmetaObject();
 
-        boolean isAuthBySysmetaSubjects = authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
+        boolean isAuthBySysmetaSubjects =
+            authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
         assertTrue(isAuthBySysmetaSubjects);
     }
 
@@ -382,13 +382,17 @@ public class D1AuthHelperTest {
     @Test
     public void testIsOther() {
 
-        Assert.assertFalse("otherSession should not be authorized as a CN", authDel.isCNAdmin(otherMNSession, nl));
-        Assert.assertFalse("otherSession should not be authorized as the authMN", 
-                authDel.isAuthoritativeMNodeAdmin(otherMNSession, TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"), nl));
-        Assert.assertFalse("otherSession should not be authorized as a replica MN", 
-                authDel.isReplicaMNodeAdmin(otherMNSession, sysmeta, nl));
+        Assert.assertFalse(
+            "otherSession should not be authorized as a CN", authDel.isCNAdmin(otherMNSession, nl));
+        Assert.assertFalse("otherSession should not be authorized as the authMN",
+                           authDel.isAuthoritativeMNodeAdmin(otherMNSession,
+                                                             TypeFactory.buildNodeReference(
+                                                                 "urn:node:unitTestAuthMN"), nl));
+        Assert.assertFalse("otherSession should not be authorized as a replica MN",
+                           authDel.isReplicaMNodeAdmin(otherMNSession, sysmeta, nl));
         Assert.assertFalse("otherSession should not be authorized via sysmeta subjects",
-                authDel.isAuthorizedBySysMetaSubjects(otherMNSession, sysmeta, Permission.READ));
+                           authDel.isAuthorizedBySysMetaSubjects(otherMNSession, sysmeta,
+                                                                 Permission.READ));
 
     }
 
@@ -398,13 +402,15 @@ public class D1AuthHelperTest {
     @Test
     public void testSessionIsNull() {
 
-        Assert.assertFalse("null Session should not be authorized as a CN", authDel.isCNAdmin(null, nl));
-        Assert.assertFalse("null Session should not be authorized as the authMN", 
-                authDel.isAuthoritativeMNodeAdmin(null, TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"), nl));
-        Assert.assertFalse("null Session should not be authorized as a replica MN", 
-                authDel.isReplicaMNodeAdmin(null, sysmeta, nl));
+        Assert.assertFalse(
+            "null Session should not be authorized as a CN", authDel.isCNAdmin(null, nl));
+        Assert.assertFalse("null Session should not be authorized as the authMN",
+                           authDel.isAuthoritativeMNodeAdmin(null, TypeFactory.buildNodeReference(
+                               "urn:node:unitTestAuthMN"), nl));
+        Assert.assertFalse("null Session should not be authorized as a replica MN",
+                           authDel.isReplicaMNodeAdmin(null, sysmeta, nl));
         Assert.assertFalse("null Session should not be authorized via sysmeta subjects",
-                authDel.isAuthorizedBySysMetaSubjects(null, sysmeta, Permission.READ));
+                           authDel.isAuthorizedBySysMetaSubjects(null, sysmeta, Permission.READ));
 
     }
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -280,6 +280,9 @@ public class D1AuthHelperTest {
         assertTrue(isLocalCnNodeAdmin);
     }
 
+    /**
+     * Confirm that isAuthorizedBySysMetaSubjects returns true with valid sysmeta subject
+     */
     @Test
     public void testIsAuthorizedBySysMetaSubjects() throws NoSuchAlgorithmException, NotFound, ServiceFailure, IOException {
         SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
@@ -291,7 +294,9 @@ public class D1AuthHelperTest {
         AccessPolicy ap = new AccessPolicy();
         ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
         sysmeta.setAccessPolicy(ap);
-        authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
+        boolean isAuthBySysmetaSubjects = authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
+
+        assertTrue(isAuthBySysmetaSubjects);
     }
 
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -173,10 +173,31 @@ public class D1AuthHelperTest {
         fail("Not yet implemented");
     }
 
-    @Ignore("requires client communication...")
+
+    /**
+     * Confirm that 'doCNOnlyAuthorization' does not throw exception with good subject
+     */
     @Test
     public void testDoCNOnlyAuthorization() {
-        fail("Not yet implemented");
+        Session sessionCnAdmin = new Session();
+        sessionCnAdmin.setSubject(TypeFactory.buildSubject("cn1Subject"));
+
+        try {
+            authDelMock.doCNOnlyAuthorization(sessionCnAdmin);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Confirm that 'doCNOnlyAuthorization' throws exception with bad subject
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoCNOnlyAuthorization_notApprovedSubject() throws Exception {
+        Session sessionCnAdmin = new Session();
+        sessionCnAdmin.setSubject(TypeFactory.buildSubject("notAFriend"));
+
+        authDelMock.doCNOnlyAuthorization(sessionCnAdmin);
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -155,6 +155,23 @@ public class D1AuthHelperTest {
         
     }
 
+    /**
+     * Get a minimal SystemMetadata object with default values
+     * @return
+     */
+    private SystemMetadata getGenericSysmetaObject() throws Exception {
+        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
+            TypeFactory.buildIdentifier("dip"),
+            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
+            "MD5",
+            TypeFactory.buildFormatIdentifier("text/csv"),
+            TypeFactory.buildSubject("submitterRightsHolder"));
+        AccessPolicy ap = new AccessPolicy();
+        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
+        sysmeta.setAccessPolicy(ap);
+        return sysmeta;
+    }
+
     @Ignore("Not yet implemented...")
     @Test
     public void testExpandRightsHolder() {
@@ -167,15 +184,7 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testDoUpdateAuth() throws Exception {
-        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
-            TypeFactory.buildIdentifier("dip"),
-            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
-            "MD5",
-            TypeFactory.buildFormatIdentifier("text/csv"),
-            TypeFactory.buildSubject("submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
+        SystemMetadata sysmeta = getGenericSysmetaObject();
         sysmeta.setAuthoritativeMemberNode(TypeFactory.buildNodeReference(
             "urn:node:unitTestAuthMN"));
 
@@ -286,15 +295,7 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testDoGetSysmetaAuthorization() throws Exception {
-        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
-            TypeFactory.buildIdentifier("dip"),
-            new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")),
-            "MD5",
-            TypeFactory.buildFormatIdentifier("text/csv"),
-            TypeFactory.buildSubject("submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
+        SystemMetadata sysmeta = getGenericSysmetaObject();
 
         try {
             authDel.doGetSysmetaAuthorization(session, sysmeta, Permission.WRITE);
@@ -308,18 +309,10 @@ public class D1AuthHelperTest {
      * Confirm that isAuthorizedBySysMetaSubjects returns true with valid sysmeta subject
      */
     @Test
-    public void testIsAuthorizedBySysMetaSubjects() throws NoSuchAlgorithmException, NotFound, ServiceFailure, IOException {
-        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
-                TypeFactory.buildIdentifier("dip"), 
-                new ByteArrayInputStream(("tra la la la la").getBytes("UTF-8")), 
-                "MD5", 
-                TypeFactory.buildFormatIdentifier("text/csv"), 
-                TypeFactory.buildSubject("submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
-        boolean isAuthBySysmetaSubjects = authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
+    public void testIsAuthorizedBySysMetaSubjects() throws Exception {
+        SystemMetadata sysmeta = getGenericSysmetaObject();
 
+        boolean isAuthBySysmetaSubjects = authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
         assertTrue(isAuthBySysmetaSubjects);
     }
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -31,6 +31,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import edu.ucsb.nceas.LeanTestUtils;
+import org.mockito.Mockito;
 
 public class D1AuthHelperTest {
 
@@ -84,6 +85,7 @@ public class D1AuthHelperTest {
     }
 
     D1AuthHelper authDel;
+    D1AuthHelper authDelMock;
     Session session;
     Session authMNSession;
     Session otherMNSession;
@@ -97,6 +99,9 @@ public class D1AuthHelperTest {
         LeanTestUtils.initializePropertyService(LeanTestUtils.PropertiesMode.UNIT_TEST);
         
         authDel = new D1AuthHelper(null,TypeFactory.buildIdentifier("foo"),"1234NA","5678SF");
+        // Create a D1AuthHelper mock to prevent network dependencies
+        authDelMock = Mockito.spy(authDel);
+        Mockito.doReturn(nl).when(authDelMock).getCNNodeList();
         
         //build a SystemMetadata object
         sysmeta = TypeFactory.buildMinimalSystemMetadata(
@@ -180,20 +185,21 @@ public class D1AuthHelperTest {
     @Test
     public void testDoAdminAuthorization_metacatAdmin() throws Exception {
         Session sessionMetacatAdmin = new Session();
-        sessionMetacatAdmin.setSubject(TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+        sessionMetacatAdmin.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
 
-        authDel.doAdminAuthorization(sessionMetacatAdmin);
+        authDelMock.doAdminAuthorization(sessionMetacatAdmin);
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' accepts cnAdmin
+     * Confirm that 'doAdminAuthorization' accepts cnAdmin ("cn1Subject")
      */
     @Test
     public void testDoAdminAuthorization_cnAdmin() throws Exception {
         Session sessionCnAdmin = new Session();
-        sessionCnAdmin.setSubject(TypeFactory.buildSubject("CN=urn:node:CN,DC=dataone,DC=org"));
+        sessionCnAdmin.setSubject(TypeFactory.buildSubject("cn1Subject"));
 
-        authDel.doAdminAuthorization(sessionCnAdmin);
+        authDelMock.doAdminAuthorization(sessionCnAdmin);
     }
 
     /**
@@ -202,9 +208,10 @@ public class D1AuthHelperTest {
     @Test
     public void testDoAdminAuthorization_localNodeAdmin() throws Exception {
         Session sessionLocalNodeAdmin = new Session();
-        sessionLocalNodeAdmin.setSubject(TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
+        sessionLocalNodeAdmin.setSubject(
+            TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
 
-        authDel.doAdminAuthorization(sessionLocalNodeAdmin);
+        authDelMock.doAdminAuthorization(sessionLocalNodeAdmin);
     }
 
 
@@ -214,7 +221,7 @@ public class D1AuthHelperTest {
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_notAuthorized() throws Exception {
-        authDel.doAdminAuthorization(session);
+        authDelMock.doAdminAuthorization(session);
     }
 
     @Ignore("requires client communication...")

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -99,7 +99,7 @@ public class D1AuthHelperTest {
         LeanTestUtils.initializePropertyService(LeanTestUtils.PropertiesMode.UNIT_TEST);
         
         authDel = new D1AuthHelper(null,TypeFactory.buildIdentifier("foo"),"1234NA","5678SF");
-        // Create a D1AuthHelper mock to prevent network dependencies
+        // Create a D1AuthHelper mock for tests that make network calls (ex. getCNNodeList)
         authDelMock = Mockito.spy(authDel);
         Mockito.doReturn(nl).when(authDelMock).getCNNodeList();
         

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -304,6 +304,9 @@ public class D1AuthHelperTest {
         authDel.isAuthoritativeMNodeAdmin(session, TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"), nl);
     }
 
+    /**
+     * Confirm that isCNAdmin recognizes a CN session.
+     */
     @Test
     public void testIsCNAdmin() {
         boolean isCNAdmin = authDel.isCNAdmin(cn1CNSession, nl);

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -155,7 +155,13 @@ public class D1AuthHelperTest {
         
     }
 
-    @Ignore("requires client communication...")
+    @Ignore("Not yet implemented...")
+    @Test
+    public void testExpandRightsHolder() {
+        fail("Not yet implemented");
+    }
+
+    @Ignore("Not yet implemented...")
     @Test
     public void testDoUpdateAuth() {
         fail("Not yet implemented");
@@ -239,12 +245,6 @@ public class D1AuthHelperTest {
     public void testPrepareAndThrowNotAuthorized() throws Exception {
         authDel.prepareAndThrowNotAuthorized(
             session, TypeFactory.buildIdentifier("dip"), Permission.READ, "3456dc");
-    }
-
-    @Ignore("requires client communication...")
-    @Test
-    public void testExpandRightsHolder() {
-        fail("Not yet implemented");
     }
 
     /**
@@ -361,6 +361,10 @@ public class D1AuthHelperTest {
         assertTrue(isCNAdmin);
     }
 
+    /**
+     * Test commonly used methods return false when session (otherMNSession) subject is
+     * otherMNSubject (not approved)
+     */
     @Test
     public void testIsOther() {
 
@@ -374,6 +378,9 @@ public class D1AuthHelperTest {
 
     }
 
+    /**
+     * Test commonly used methods return false when session is null
+     */
     @Test
     public void testSessionIsNull() {
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -8,9 +8,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
-
-
-
 import org.dataone.service.exceptions.NotAuthorized;
 import org.dataone.service.exceptions.NotFound;
 import org.dataone.service.exceptions.ServiceFailure;
@@ -33,7 +30,10 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-
+import edu.ucsb.nceas.LeanTestUtils;
+import edu.ucsb.nceas.metacat.util.AuthUtil;
+import edu.ucsb.nceas.metacat.properties.PropertiesWrapper;
+import org.mockito.Mockito;
 
 public class D1AuthHelperTest {
 
@@ -96,6 +96,8 @@ public class D1AuthHelperTest {
     
     @Before
     public void setUp() throws Exception {
+
+        LeanTestUtils.initializePropertyService(LeanTestUtils.PropertiesMode.UNIT_TEST);
         
         authDel = new D1AuthHelper(null,TypeFactory.buildIdentifier("foo"),"1234NA","5678SF");
         
@@ -175,10 +177,46 @@ public class D1AuthHelperTest {
         fail("Not yet implemented");
     }
 
-    @Ignore("requires client communication...")
+    /**
+     * Confirm that 'doAdminAuthorization' accepts Metacat auth.administrator
+     */
     @Test
-    public void testDoAdminAuthorization() {
-        fail("Not yet implemented");
+    public void testDoAdminAuthorization_metacatAdmin() throws Exception {
+        Session sessionTwo = new Session();
+        sessionTwo.setSubject(TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+        authDel.doAdminAuthorization(sessionTwo);
+    }
+
+    /**
+     * Confirm that 'doAdminAuthorization' accepts correct cnAdmin
+     */
+    @Test
+    public void testDoAdminAuthorization_cnAdmin() throws Exception {
+        Session sessionTwo = new Session();
+        sessionTwo.setSubject(TypeFactory.buildSubject("CN=urn:node:CN,DC=dataone,DC=org"));
+
+        authDel.doAdminAuthorization(sessionTwo);
+    }
+
+    /**
+     * Confirm that 'doAdminAuthorization' accepts correct localNodeAdmin
+     */
+    @Test
+    public void testDoAdminAuthorization_localNodeAdmin() throws Exception {
+        Session sessionThree = new Session();
+        sessionThree.setSubject(TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
+
+        authDel.doAdminAuthorization(sessionThree);
+    }
+
+
+    /**
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoAdminAuthorization_notAuthorized() throws Exception {
+        authDel.doAdminAuthorization(session);
     }
 
     @Ignore("requires client communication...")
@@ -225,7 +263,6 @@ public class D1AuthHelperTest {
 
     @Test
     public void testIsReplicaMNodeAdmin() {
-        
         authDel.isReplicaMNodeAdmin(session, sysmeta, nl);
     }
 
@@ -238,7 +275,7 @@ public class D1AuthHelperTest {
     public void testIsCNAdmin() {
         authDel.isCNAdmin(cn1CNSession, nl);
     }
-    
+
     @Test
     public void testIsOther() {
 
@@ -251,7 +288,7 @@ public class D1AuthHelperTest {
                 authDel.isAuthorizedBySysMetaSubjects(otherMNSession, sysmeta, Permission.READ));
 
     }
-    
+
     @Test
     public void testSessionIsNull() {
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -294,9 +294,28 @@ public class D1AuthHelperTest {
         authDel.isAuthorizedBySysMetaSubjects(session, sysmeta, Permission.WRITE);
     }
 
+
+    /**
+     * Confirm isReplicaMNNodeAdmin returns false with incorrect session subject
+     */
     @Test
-    public void testIsReplicaMNodeAdmin() {
-        authDel.isReplicaMNodeAdmin(session, sysmeta, nl);
+    public void testIsReplicaMNodeAdmin_validMnSubject() {
+        Session sessionReplicaMNSubject = new Session();
+        sessionReplicaMNSubject.setSubject(TypeFactory.buildSubject("replMNSubject"));
+        boolean isReplicaMNNodeAdmin =
+            authDel.isReplicaMNodeAdmin(sessionReplicaMNSubject, sysmeta, nl);
+
+        assertTrue(isReplicaMNNodeAdmin);
+    }
+
+    /**
+     * Confirm isReplicaMNNodeAdmin returns false with incorrect session subject
+     */
+    @Test
+    public void testIsReplicaMNodeAdmin_invalidMnSubject() {
+        boolean isReplicaMNNodeAdmin = authDel.isReplicaMNodeAdmin(session, sysmeta, nl);
+
+        assertFalse(isReplicaMNNodeAdmin);
     }
 
     /**

--- a/test/test.properties
+++ b/test/test.properties
@@ -12,3 +12,4 @@ guid.doi.password=apitest
 application.backupDir=/var/metacat/.metacat
 solr.targetSpecVersion=8.11.3
 solr.schemField.size=165
+auth.administrators=http\\\://orcid.org/0000-0002-6076-8092:http\\\://orcid.org/0000-0003-0077-4738


### PR DESCRIPTION
Summary of Changes:
- Added code to `doAdminAuthorization` method in `D1Authhelper.java` class to also check whether session subject is a Metacat admin user (part of the auth.administrators list) to determine MN Node access privileges.

Hi @taojing2002 - When you have a moment, can you please review my PR? @artntek If you have a moment, your feedback is welcome too.