### PR TITLE
Feature-1816: Metacat Admin MN Privileges (auth.administrators) - Resolve Broken Tests

### DIFF
--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -387,10 +387,7 @@ public class D1AuthHelper {
         try {
             logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + sessionSubject
                 + " for Metacat admin privileges.");
-            if (!AuthUtil.isAdministrator(sessionSubject, null)) {
-                throw new NotAuthorized(
-                    "0000", "Subject is not an administrator: " + sessionSubject);
-            } else {
+            if (AuthUtil.isAdministrator(sessionSubject, null)) {
                 return;
             }
         } catch (MetacatUtilException mue) {

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -365,13 +365,24 @@ public class D1AuthHelper {
         // If subject is not a LocalNodeAdmin or CNAdmin, check to see if subject is a
         // Metacat admin (auth.administrators) - who also have admin privileges like the above
         try {
-            String adminUser = session.getSubject().getValue();
-            if (adminUser != null) {
-                logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + adminUser +
-                                     " for Metacat admin privileges.");
-                if (AuthUtil.isAdministrator(adminUser, null)) {
-                    return;
+            // If session is null, there is no user so admin is not authorized.
+            if (session != null) {
+                String adminUser = session.getSubject().getValue();
+                if (adminUser != null) {
+                    logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + adminUser
+                        + " for Metacat admin privileges.");
+                    if (adminUser.trim().isEmpty()) {
+                        throw new NotAuthorized(
+                            "0000", "Session is not null, but adminUser is empty.");
+                    }
+                    if (AuthUtil.isAdministrator(adminUser, null)) {
+                        return;
+                    }
+                } else {
+                    throw new NotAuthorized("0000", "Session is not null, but adminUser is null.");
                 }
+            } else {
+                throw new NotAuthorized("0000", "Session is null.");
             }
         } catch (MetacatUtilException mue) {
             ServiceFailure sf = new ServiceFailure("0000", mue.getMessage());

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -359,7 +359,7 @@ public class D1AuthHelper {
                 "D1AuthHelper.doAdminAuthorization - The session subject value to check is: "
                     + sessionSubject);
         } catch (NullPointerException npe) {
-            throw new NotAuthorized("0000", "Subject session is not set.");
+            throw new NotAuthorized("0000", "Session subject is not set.");
         }
 
         // Create exception list that will be checked for errors

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -352,7 +352,7 @@ public class D1AuthHelper {
             if (sessionSubject == null) {
                 throw new NotAuthorized("0000", "Session is not null, but subject value is null.");
             }
-            if (sessionSubject.trim().isEmpty()) {
+            if (sessionSubject.trim().isBlank()) {
                 throw new NotAuthorized("0000", "Session is not null, but subject value is empty.");
             }
             logMetacat.debug(

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -394,10 +394,14 @@ public class D1AuthHelper {
             exceptions.add(sf);
         }
 
+        // This is a guard rail. An exception will be thrown if the JVM reaches this part of
+        // the code and exceptions list is empty. Unless a session subject is explicitly authorized,
+        // the session is not authorized.
         if (exceptions.isEmpty()) {
             prepareAndThrowNotAuthorized(session, requestIdentifier, null, notAuthorizedCode);
         } else {
-            // just use the first one
+            // If there is an error when attempting to determine admin privileges,
+            // pick the first exception and throw it.
             ServiceFailure sf = exceptions.get(0);
             sf.setDetail_code(serviceFailureCode);
             throw sf;

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -37,7 +37,7 @@ import org.dataone.service.types.v2.Node;
 import org.dataone.service.types.v2.NodeList;
 import org.dataone.service.types.v2.SystemMetadata;
 import org.dataone.service.types.v2.util.NodelistUtil;
-
+import org.mockito.internal.matchers.Null;
 
 
 /**
@@ -345,18 +345,22 @@ public class D1AuthHelper {
         if (session == null) {
             throw new NotAuthorized("0000", "Session is null.");
         }
-        // If there is no subject or if subject is empty, session is not authorized.
-        String sessionSubject = session.getSubject().getValue();
-        if (sessionSubject == null) {
-            throw new NotAuthorized(
-                "0000", "Session is not null, but subject value is null.");
+        // If there is an empty session/no subject or if subject is blank, session is not authorized.
+        String sessionSubject;
+        try {
+            sessionSubject = session.getSubject().getValue();
+            if (sessionSubject == null) {
+                throw new NotAuthorized("0000", "Session is not null, but subject value is null.");
+            }
+            if (sessionSubject.trim().isEmpty()) {
+                throw new NotAuthorized("0000", "Session is not null, but subject value is empty.");
+            }
+            logMetacat.debug(
+                "D1AuthHelper.doAdminAuthorization - The session subject value to check is: "
+                    + sessionSubject);
+        } catch (NullPointerException npe) {
+            throw new NotAuthorized("0000", "Subject session is not set.");
         }
-        if (sessionSubject.trim().isEmpty()) {
-            throw new NotAuthorized("0000", "Session is not null, but subject value is empty.");
-        }
-        logMetacat.debug(
-            "D1AuthHelper.doAdminAuthorization - The session subject value to check is: "
-                + sessionSubject);
 
         // Create exception list that will be checked for errors
         List<ServiceFailure> exceptions = new ArrayList<>();

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -383,11 +383,11 @@ public class D1AuthHelper {
         try {
             logMetacat.debug("D1AuthHelper.doAdminAuthorization: Checking " + sessionSubject
                 + " for Metacat admin privileges.");
-            if (AuthUtil.isAdministrator(sessionSubject, null)) {
-                return;
-            } else {
+            if (!AuthUtil.isAdministrator(sessionSubject, null)) {
                 throw new NotAuthorized(
                     "0000", "Subject is not an administrator: " + sessionSubject);
+            } else {
+                return;
             }
         } catch (MetacatUtilException mue) {
             ServiceFailure sf = new ServiceFailure("0000", mue.getMessage());

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -400,7 +400,7 @@ public class D1AuthHelper {
         if (exceptions.isEmpty()) {
             prepareAndThrowNotAuthorized(session, requestIdentifier, null, notAuthorizedCode);
         } else {
-            // If there is an error when attempting to determine admin privileges,
+            // If there are multiple errors when attempting to determine admin privileges,
             // pick the first exception and throw it.
             ServiceFailure sf = exceptions.get(0);
             sf.setDetail_code(serviceFailureCode);

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -248,43 +248,47 @@ public class D1AuthHelperTest {
 
     /**
      * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with unauthorized
-     * subject.
+     * subject from session.
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_notAuthorized() throws Exception {
-        authDelMock.doAdminAuthorization(session);
+        Session sessionRandomUser = new Session();
+        sessionRandomUser.setSubject(
+            TypeFactory.buildSubject("IAmNotAuthorized"));
+
+        authDelMock.doAdminAuthorization(sessionRandomUser);
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is not null
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception when session is not null
      * and subject is null.
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_nullSessionSubject() throws Exception {
-        Session sessionLocalNodeAdmin = new Session();
-        sessionLocalNodeAdmin.setSubject(
+        Session sessionNullSubject = new Session();
+        sessionNullSubject.setSubject(
             TypeFactory.buildSubject(null));
 
 
-        authDelMock.doAdminAuthorization(null);
+        authDelMock.doAdminAuthorization(sessionNullSubject);
     }
 
     /**
-     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is not null
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception when session is not null
      * and subject is empty.
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_emptySessionSubject() throws Exception {
-        Session sessionLocalNodeAdmin = new Session();
-        sessionLocalNodeAdmin.setSubject(
+        Session sessionEmptySubject = new Session();
+        sessionEmptySubject.setSubject(
             TypeFactory.buildSubject(""));
 
-        authDelMock.doAdminAuthorization(null);
+        authDelMock.doAdminAuthorization(sessionEmptySubject);
     }
 
 
     /**
-     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is null
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception when session is null
      */
     @Test(expected = NotAuthorized.class)
     public void testDoAdminAuthorization_nullSession() throws Exception {

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -185,6 +185,20 @@ public class D1AuthHelperTest {
     }
 
     /**
+     * Check that doUpdateAuth throws exception when 'authoritativeMemberNode' is not the same
+     * as what is found in the sysmeta object.
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoUpdateAuth_mismatchedAuthMNode() throws Exception {
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestOtherMN"));
+
+        authDelMock.doUpdateAuth(session, sysmetaEdited, Permission.CHANGE_PERMISSION,
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+    }
+
+    /**
      * Confirm that 'doCNOnlyAuthorization' does not throw exception with good subject
      */
     @Test
@@ -220,6 +234,19 @@ public class D1AuthHelperTest {
             TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
 
         authDelMock.doAdminAuthorization(sessionMetacatAdmin);
+    }
+
+    /**
+     * Confirm that 'doAdminAuthorization' accepts another Metacat admin in the
+     * auth.administrator's list.
+     */
+    @Test
+    public void testDoAdminAuthorization_anotherMetacatAdmin() throws Exception {
+        Session sessionMetacatAdminTwo = new Session();
+        sessionMetacatAdminTwo.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0003-0077-4738"));
+
+        authDelMock.doAdminAuthorization(sessionMetacatAdminTwo);
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -269,8 +269,18 @@ public class D1AuthHelperTest {
         sessionNullSubject.setSubject(
             TypeFactory.buildSubject(null));
 
-
         authDelMock.doAdminAuthorization(sessionNullSubject);
+    }
+
+    /**
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception when session subject
+     * is never set (empty session).
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoAdminAuthorization_missingSubject() throws Exception {
+        Session sessionNoSubjectSet = new Session();
+
+        authDelMock.doAdminAuthorization(sessionNoSubjectSet);
     }
 
     /**

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -256,6 +256,43 @@ public class D1AuthHelperTest {
     }
 
     /**
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is not null
+     * and subject is null.
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoAdminAuthorization_nullSessionSubject() throws Exception {
+        Session sessionLocalNodeAdmin = new Session();
+        sessionLocalNodeAdmin.setSubject(
+            TypeFactory.buildSubject(null));
+
+
+        authDelMock.doAdminAuthorization(null);
+    }
+
+    /**
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is not null
+     * and subject is empty.
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoAdminAuthorization_emptySessionSubject() throws Exception {
+        Session sessionLocalNodeAdmin = new Session();
+        sessionLocalNodeAdmin.setSubject(
+            TypeFactory.buildSubject(""));
+
+        authDelMock.doAdminAuthorization(null);
+    }
+
+
+    /**
+     * Confirm that 'doAdminAuthorization' throws NotAuthorized exception with session is null
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoAdminAuthorization_nullSession() throws Exception {
+        authDelMock.doAdminAuthorization(null);
+    }
+
+
+    /**
      * Confirm that prepareAndThrowNotAuthorized throws NotAuthorized exception with invalid
      * session
      */


### PR DESCRIPTION
Hi @taojing2002, I have amended `doAdminAuthorization` in `D1AuthHelper` to throw `NotAuthorized` exceptions when session is null, and when session is not null but subject is empty or null. Can you please let me know if you are experiencing any other errors?