### PR TITLE
Bugfix-1837: Metacat Admin Privileges Extended

### DIFF
--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -817,7 +817,7 @@ public class D1AuthHelper {
                             }
                         } catch (MetacatUtilException mue) {
                             // Do nothing, continue checking for local node admins
-                            logMetacat.debug("Unexpected issue when checking for Metacat "
+                            logMetacat.warn("Unexpected issue when checking for Metacat "
                                                  + "Admin privileges: " + mue.getMessage());
                         }
                     }

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -36,10 +36,9 @@ import org.dataone.service.types.v2.util.NodelistUtil;
 
 
 /**
- * This is delegate class for D1NodeService and subclasses.
- * It centralizes authorization implementations to make them
- * more consistent across the various API methods, and more testable.
- * 
+ * This is delegate class for D1NodeService and subclasses. It centralizes authorization
+ * implementations to make them more consistent across the various API methods, and more testable.
+ *
  * There are 6 basic authorization checks that can be done, and these
  * are implemented as protected methods in this class.  these checks are:
  * 1. session vs. systemMetadata subjects
@@ -48,21 +47,20 @@ import org.dataone.service.types.v2.util.NodelistUtil;
  * 4. session vs. CN nodelist subjects (checking for CN admin authorization)
  * 5. session vs. systemMetadata replica nodeReferences (via nodelist subjects)
  * 6. session vs. expanded rightsHolder equivalent subjects and groups. (uses API calls to the CN)
- * 
- * 
+ *
  * In practice, there are currently only a handful of combinations of authorization checks being used.
  * These are represented by the public methods in this class.
  * If more combinations are ever required, they should be added as a new public method,
  * and follow the general way the other methods are implemented.
- * 
+ *
  * The combinations in use are:
  * 1. CN admin only
  * 2. Local or AuthoritativeMN only
- * 3. Local MN or CN admin only 
+ * 3. Local MN or CN admin only
  * 4. "isAuthorized" - all checks except allowing replica nodes
  * 5. "getSystemMetadata" - all checks
  * 6. "update" authorization - success depends on the local node being the authMN
- * 
+ *
  * @author rnahf
  *
  */
@@ -76,16 +74,6 @@ public class D1AuthHelper {
     private String serviceFailureCode;
     private Identifier requestIdentifier;
     private static NodeList cnList = null;
-    
-    /**
-     * Each instance should correspond to a single request.
-     * @param request
-     * @param hzSystemMetadataMap
-     */
-//    public D1AuthorizationDelegate(HttpServletRequest request, Map<Identifier,SystemMetadata> hzSystemMetadataMap) {
-//        this.request = request;
-//        this.sysmetaMap = hzSystemMetadataMap;       
-//    }
 
     /**
      * Each instance should correspond to a single request.
@@ -354,7 +342,7 @@ public class D1AuthHelper {
         List<ServiceFailure> exceptions = new ArrayList<>();
 
         try {
-            // This will also check session for metacat admin privileges
+            // This will also check session for Metacat admin privileges
             if (this.isLocalNodeAdmin(session, null)) {
                 return;
             }
@@ -488,16 +476,16 @@ public class D1AuthHelper {
     protected void prepareAndThrowNotAuthorized(Session session, Identifier pid, Permission permission, String detailCode) throws NotAuthorized {
         
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
-        StringBuffer includedSubjects = new StringBuffer();
+        StringBuilder includedSubjects = new StringBuilder();
         for (Subject s: sessionSubjects) {
-            includedSubjects.append(s.getValue() + "; ");
+            includedSubjects.append(s.getValue()).append("; ");
         } 
         
         String msg = String.format(
                 "%s not allowed on %s for subject[s]: %s",
                     permission == null ? "Permission" : permission,
                     pid == null ? null : pid.getValue(),
-                    includedSubjects.toString()
+                    includedSubjects
                     );
         logMetacat.warn(msg);
         throw new NotAuthorized(detailCode, msg);   
@@ -719,7 +707,7 @@ public class D1AuthHelper {
      *
      * @param session  User session to check
      * @param nodeType Type of node desired to check (ex. NodeType.MN or NodeType.CN))
-     * @return True if session subject is a local node admin or metacat admin
+     * @return True if session subject is a local node admin or Metacat admin
      * @throws ServiceFailure When there is an issue checking for authorization
      */
     protected boolean isLocalNodeAdmin(Session session, NodeType nodeType) throws ServiceFailure {
@@ -757,7 +745,7 @@ public class D1AuthHelper {
                             break outer;
                         }
                     }
-                    // If not, check session subject for a metacat admin
+                    // If not, check session subject for a Metacat admin
                     String subjectValue = subject.getValue();
                     if (subjectValue != null && !subjectValue.isBlank()) {
                         logMetacat.debug("D1AuthHelper.isLocalNodeAdmin(), checking " + subjectValue
@@ -790,25 +778,23 @@ public class D1AuthHelper {
      * @param permission Permission level to check
      * @return True if authorized based on the sysmeta subject
      */
-    protected boolean isAuthorizedBySysMetaSubjects(Session session, SystemMetadata sysmeta, Permission permission) {
+    protected boolean isAuthorizedBySysMetaSubjects(
+        Session session, SystemMetadata sysmeta, Permission permission) {
 
         // get the subject[s] from the session
         // defer to the shared util for recursively compiling the subjects   
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
-        
-        if(logMetacat.isDebugEnabled()) {
-            if(sessionSubjects != null) {
-                for(Subject subject : sessionSubjects) {
-                    logMetacat.debug("=================== The equalvent subject is "+subject.getValue());
+
+        if (logMetacat.isDebugEnabled()) {
+            if (sessionSubjects != null) {
+                for (Subject subject : sessionSubjects) {
+                    logMetacat.debug(
+                        "=================== The equivalent subject is " + subject.getValue());
                 }
-            } 
+            }
         }
 
-        if (AuthUtils.isAuthorized(sessionSubjects, permission, sysmeta)) {
-            return true;
-        }
-
-        return false;
+        return AuthUtils.isAuthorized(sessionSubjects, permission, sysmeta);
     }
 
 
@@ -826,7 +812,7 @@ public class D1AuthHelper {
 
         Subject subject = session == null ? null : session.getSubject();
         List<Replica> replicaList = sysmeta.getReplicaList();
-        NodeReference replicaNodeRef = null;
+        NodeReference replicaNodeRef;
 
         if  ( replicaList != null && subject != null ) {
             // get the list of nodes with a matching node subject

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -121,8 +121,7 @@ public class D1AuthHelper {
         } catch(ServiceFailure e) {
             exceptions.add(e);
         }
-        
-        
+
         try {
             NodeList nodelist = this.getCNNodeList();
 
@@ -140,8 +139,9 @@ public class D1AuthHelper {
 
         // this makes 1 or more calls to listSubjects, so is the most expensive
         try {
-            logMetacat.debug("D1AuthHelper.doIsAuthorized - Checking expanded permissions");
             if (this.checkExpandedPermissions(session, sysmeta, permission)) {
+                logMetacat.debug("D1AuthHelper.doIsAuthorized - Expanded permissions checked and "
+                                     + "is true (authorized)");
                 return;
             }
         }

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -819,6 +819,8 @@ public class D1AuthHelper {
                             }
                         } catch (MetacatUtilException mue) {
                             // Do nothing, continue checking for local node admins
+                            logMetacat.debug("Unexpected issue when checking for Metacat "
+                                                 + "Admin privileges: " + mue.getMessage());
                         }
                     }
                 }

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -118,7 +118,7 @@ public class D1AuthHelper {
     public void doIsAuthorized(Session session, SystemMetadata sysmeta, Permission permission) throws ServiceFailure, NotAuthorized
     {
         if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHepler.doIsAuthorzied - the session is "+session.getSubject().getValue());
+            logMetacat.debug("D1AuthHelper.doIsAuthorized - the session is "+session.getSubject().getValue());
         }
         List<ServiceFailure> exceptions = new ArrayList<>();
         // most efficient step first - uses materials passed in
@@ -153,6 +153,7 @@ public class D1AuthHelper {
 
         // this makes 1 or more calls to listSubjects, so is the most expensive
         try {
+            logMetacat.debug("D1AuthHelper.doIsAuthorized - Checking expanded permissions");
             if (this.checkExpandedPermissions(session, sysmeta, permission)) {
                 return;
             }

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -763,7 +763,7 @@ public class D1AuthHelper {
                     }
                     // If not, check session subject for a metacat admin
                     String subjectValue = subject.getValue();
-                    if (subjectValue != null && !subjectValue.trim().isBlank()) {
+                    if (subjectValue != null && !subjectValue.isBlank()) {
                         logMetacat.debug("D1AuthHelper.isLocalNodeAdmin(), checking " + subjectValue
                             + " for Metacat admin privileges.");
                         try {

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -763,7 +763,7 @@ public class D1AuthHelper {
                     }
                     // If not, check session subject for a metacat admin
                     String subjectValue = subject.getValue();
-                    if (subjectValue != null || !subjectValue.trim().isBlank()) {
+                    if (subjectValue != null && !subjectValue.trim().isBlank()) {
                         logMetacat.debug("D1AuthHelper.isLocalNodeAdmin(), checking " + subjectValue
                             + " for Metacat admin privileges.");
                         try {

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -695,30 +695,28 @@ public class D1AuthHelper {
                 "D1AuthHelper.isInGroups -  the given groups' (the returned result including "
                     + "groups) size is " + groups.size());
             for (Group group : groups) {
-                Subject groupSubject = group.getSubject();
-                String groupSubjectValue = group.getSubject().getValue();
-                if (group != null && groupSubject != null && groupSubject.equals(rightHolder)) {
+                if (group != null && group.getSubject() != null && group.getSubject()
+                    .equals(rightHolder)) {
                     logMetacat.debug(
                         "D1AuthHelper.isInGroups - there is a group in the list having the "
-                            + "subject " + groupSubjectValue
+                            + "subject " + group.getSubject().getValue()
                             + " which matches the right holder's subject "
                             + rightHolder.getValue());
                     List<Subject> members = group.getHasMemberList();
                     if (members != null) {
-                        logMetacat.debug("D1AuthHelper.isInGroups - the group " + groupSubjectValue
-                                             + " in the cn has members");
+                        logMetacat.debug(
+                            "D1AuthHelper.isInGroups - the group " + group.getSubject().getValue()
+                                + " in the cn has members");
                         for (Subject member : members) {
-                            String memberValue = member.getValue();
-                            String userSessionValue = userSession.getValue();
                             logMetacat.debug(
-                                "D1AuthHelper.isInGroups - compare the member " + memberValue
-                                    + " with the user " + userSessionValue);
-                            if (memberValue != null && !memberValue.isBlank() && memberValue.equals(
-                                userSessionValue)) {
-                                logMetacat.debug(
-                                    "D1AuthHelper.isInGroups - Find it! The member " + memberValue
-                                        + " in the group " + groupSubjectValue
-                                        + " matches the user " + userSessionValue);
+                                "D1AuthHelper.isInGroups - compare the member " + member.getValue()
+                                    + " with the user " + userSession.getValue());
+                            if (member.getValue() != null && !member.getValue().isBlank() && member
+                                .getValue().equals(userSession.getValue())) {
+                                logMetacat.debug("D1AuthHelper.isInGroups - Found it! The member "
+                                                     + member.getValue() + " in the group " + group
+                                    .getSubject().getValue() + " matches the user "
+                                                     + userSession.getValue());
                                 is = true;
                                 return is;
                             }

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -2,16 +2,13 @@ package edu.ucsb.nceas.metacat.dataone;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
 import edu.ucsb.nceas.metacat.shared.MetacatUtilException;
 import edu.ucsb.nceas.metacat.util.AuthUtil;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Level;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dataone.client.v2.CNode;
@@ -19,7 +16,6 @@ import org.dataone.client.v2.itk.D1Client;
 import org.dataone.service.exceptions.InvalidRequest;
 import org.dataone.service.exceptions.InvalidToken;
 import org.dataone.service.exceptions.NotAuthorized;
-import org.dataone.service.exceptions.NotFound;
 import org.dataone.service.exceptions.NotImplemented;
 import org.dataone.service.exceptions.ServiceFailure;
 import org.dataone.service.types.v1.Group;
@@ -37,7 +33,6 @@ import org.dataone.service.types.v2.Node;
 import org.dataone.service.types.v2.NodeList;
 import org.dataone.service.types.v2.SystemMetadata;
 import org.dataone.service.types.v2.util.NodelistUtil;
-import org.mockito.internal.matchers.Null;
 
 
 /**

--- a/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/D1AuthHelper.java
@@ -102,55 +102,55 @@ public class D1AuthHelper {
      * @throws ServiceFailure When unable to check for authorization
      * @throws NotAuthorized  When session is not authorized
      */
-    public void doIsAuthorized(Session session, SystemMetadata sysmeta, Permission permission) throws ServiceFailure, NotAuthorized
-    {
-        if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHelper.doIsAuthorized - the session is "+session.getSubject().getValue());
+    public void doIsAuthorized(Session session, SystemMetadata sysmeta, Permission permission)
+        throws ServiceFailure, NotAuthorized {
+        if (session != null && session.getSubject() != null) {
+            logMetacat.debug(
+                "D1AuthHelper.doIsAuthorized - the session is " + session.getSubject().getValue());
         }
         List<ServiceFailure> exceptions = new ArrayList<>();
-        // most efficient step first - uses materials passed in
+        // First check the given parameters
         if (this.isAuthorizedBySysMetaSubjects(session, sysmeta, permission)) {
             return;
         }
-        // next most efficient step: checks against local node document built via system properties 
+        // Then check against the local node document built via Metacat properties
         try {
             if (this.isLocalNodeAdmin(session, null)) {
                 return;
             }
-        
-        } catch(ServiceFailure e) {
+
+        } catch (ServiceFailure e) {
             exceptions.add(e);
         }
 
         try {
             NodeList nodelist = this.getCNNodeList();
-
-            // these all compare the session to the nodelist in some way
-            if (this.isAuthoritativeMNodeAdmin(session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
+            // These all compare the session to the nodelist in some way
+            if (this.isAuthoritativeMNodeAdmin(
+                session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
                 return;
             }
             if (this.isCNAdmin(session, nodelist)) {
                 return;
             }
-        
+
         } catch (ServiceFailure e) {
             exceptions.add(e);
         }
 
-        // this makes 1 or more calls to listSubjects, so is the most expensive
+        // This makes 1 or more calls to listSubjects, so is the most expensive
         try {
             if (this.checkExpandedPermissions(session, sysmeta, permission)) {
                 logMetacat.debug("D1AuthHelper.doIsAuthorized - Expanded permissions checked and "
                                      + "is true (authorized)");
                 return;
             }
-        }
-        catch (ServiceFailure e) {
+        } catch (ServiceFailure e) {
             exceptions.add(e);
         }
-        
-        if (exceptions.isEmpty()) { 
-            prepareAndThrowNotAuthorized(session,requestIdentifier, permission, notAuthorizedCode); 
+
+        if (exceptions.isEmpty()) {
+            prepareAndThrowNotAuthorized(session, requestIdentifier, permission, notAuthorizedCode);
         } else {
             // just use the first one
             ServiceFailure sf = exceptions.get(0);
@@ -167,13 +167,15 @@ public class D1AuthHelper {
      * @throws ServiceFailure When unable to check for authorization
      * @throws NotAuthorized  When session is not authorized
      */
-    public void doAuthoritativeMNAuthorization(Session session, SystemMetadata sysmeta)  throws ServiceFailure, NotAuthorized
-    {
-        if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHelper.doAuthoritativeMNAuthorization - the session is "+session.getSubject().getValue());
+    public void doAuthoritativeMNAuthorization(Session session, SystemMetadata sysmeta)
+        throws ServiceFailure, NotAuthorized {
+        if (session != null && session.getSubject() != null) {
+            logMetacat.debug(
+                "D1AuthHelper.doAuthoritativeMNAuthorization - the session is " + session
+                    .getSubject().getValue());
         }
         List<ServiceFailure> exceptions = new ArrayList<>();
-        
+
         try {
             if (this.isLocalNodeAdmin(session, null)) {
                 return;
@@ -182,17 +184,18 @@ public class D1AuthHelper {
             exceptions.add(e);
         }
 
-        try {     
+        try {
             NodeList nodelist = this.getCNNodeList();
-            if (this.isAuthoritativeMNodeAdmin(session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
+            if (this.isAuthoritativeMNodeAdmin(
+                session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
                 return;
             }
         } catch (ServiceFailure e) {
             exceptions.add(e);
         }
-        
-        if (exceptions.isEmpty()) { 
-            prepareAndThrowNotAuthorized(session,requestIdentifier, null, notAuthorizedCode); 
+
+        if (exceptions.isEmpty()) {
+            prepareAndThrowNotAuthorized(session, requestIdentifier, null, notAuthorizedCode);
         } else {
             // just use the first one
             ServiceFailure sf = exceptions.get(0);
@@ -209,102 +212,44 @@ public class D1AuthHelper {
      *     <li>  the session represents the MN Admin Subject</li></ul>
      *  <li>If the session represents the D1 CN, it is allowed.</li></ol>
      */
-    public void doUpdateAuth(Session session, SystemMetadata sysmeta, Permission permission, NodeReference localNodeId) 
-            throws NotAuthorized, ServiceFailure 
-    {
-        if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHelper.doUpdateAuth - the session is "+session.getSubject().getValue());
+    public void doUpdateAuth(
+        Session session, SystemMetadata sysmeta, Permission permission, NodeReference localNodeId)
+        throws NotAuthorized, ServiceFailure {
+        if (session != null && session.getSubject() != null) {
+            logMetacat.debug(
+                "D1AuthHelper.doUpdateAuth - the session is " + session.getSubject().getValue());
         }
         boolean isAuthoritativeMN = true;
-               
+
         List<ServiceFailure> exceptions = new ArrayList<>();
-        
-        if (sysmeta.getAuthoritativeMemberNode().equals(localNodeId) 
-                && StringUtils.isNotBlank(sysmeta.getAuthoritativeMemberNode().getValue()))
-        {            
+
+        if (sysmeta.getAuthoritativeMemberNode().equals(localNodeId) && StringUtils.isNotBlank(
+            sysmeta.getAuthoritativeMemberNode().getValue())) {
             if (this.isAuthorizedBySysMetaSubjects(session, sysmeta, permission)) {
                 return;
-            }     
+            }
             try {
                 if (this.isLocalMNAdmin(session)) {
                     return;
                 }
-            }
-            catch (ServiceFailure e) {
+            } catch (ServiceFailure e) {
                 exceptions.add(e);
             }
-        
+
             try {
                 if (this.checkExpandedPermissions(session, sysmeta, permission)) {
                     return;
                 }
-            }
-            catch (ServiceFailure e) {
+            } catch (ServiceFailure e) {
                 exceptions.add(e);
-            }    
+            }
         } else {
-            //this is not the authoritativeMNMessageMN. Generally, this update/updateSystem should fail. But cn can do that. So go to check the cns subject
+            // This is not the authoritativeMNMessageMN. Generally, this update/updateSystem
+            // should fail. But cn can do that. So go to check the cns subject
             isAuthoritativeMN = false;
         }
-        
+
         // (outside the above if statement on purpose)
-        try {
-            NodeList nodelist = this.getCNNodeList();
-            if( this.isCNAdmin(session, nodelist) ) {
-                return;
-            }
-        }
-        catch (ServiceFailure e) {
-            exceptions.add(e);
-        }
-
-        String authoritativeMNMessage = "clients can only call the update/updateSystemMetadata "
-            + "request on an object when it locates on its authoritative member node. "+
-               "However, the authoritative member node of the object "+sysmeta.getIdentifier().getValue()+ " on your request is "+sysmeta.getAuthoritativeMemberNode().getValue()+
-               ", which is different to the current node "+localNodeId.getValue();
-        
-        if (exceptions.isEmpty()) { 
-            if(isAuthoritativeMN) {
-                prepareAndThrowNotAuthorized(session,requestIdentifier, permission, notAuthorizedCode); 
-            } else {
-                logMetacat.warn(authoritativeMNMessage);
-                throw new NotAuthorized(notAuthorizedCode, authoritativeMNMessage);
-            }
-            
-        } else {    
-            for (ServiceFailure sf : exceptions) {
-                logMetacat.warn("For request ["+ request+"]: ServiceFailure raised:" + sf.getDescription(),sf);
-            }
-            
-            // just use the first one
-            ServiceFailure sf = exceptions.get(0);
-            sf.setDetail_code(serviceFailureCode);
-            throw sf;
-        }    
-    }
-
-    /**
-     * Does only localNode(CN)/CN authorization
-     *
-     * @param session User session to check
-     * @throws ServiceFailure When unable to check for authorization
-     * @throws NotAuthorized  When session is not authorized
-     */
-    public void doCNOnlyAuthorization(Session session) throws ServiceFailure, NotAuthorized
-    {
-        if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHelper.doCNOnlyAuthorization - the session is "+session.getSubject().getValue());
-        }
-        List<ServiceFailure> exceptions = new ArrayList<>();
-        
-        try {
-            if (this.isLocalNodeAdmin(session, NodeType.CN)) {
-                return;
-            }
-        } catch (ServiceFailure e) {
-            exceptions.add(e);
-        }
-         
         try {
             NodeList nodelist = this.getCNNodeList();
             if (this.isCNAdmin(session, nodelist)) {
@@ -314,8 +259,69 @@ public class D1AuthHelper {
             exceptions.add(e);
         }
 
-        if (exceptions.isEmpty()) { 
-            prepareAndThrowNotAuthorized(session,requestIdentifier, null, notAuthorizedCode); 
+        String authoritativeMNMessage = "clients can only call the update/updateSystemMetadata "
+            + "request on an object when it locates on its authoritative member node. "
+            + "However, the authoritative member node of the object " + sysmeta.getIdentifier()
+            .getValue() + " on your request is " + sysmeta.getAuthoritativeMemberNode().getValue()
+            + ", which is different to the current node " + localNodeId.getValue();
+
+        if (exceptions.isEmpty()) {
+            if (isAuthoritativeMN) {
+                prepareAndThrowNotAuthorized(
+                    session, requestIdentifier, permission, notAuthorizedCode);
+            } else {
+                logMetacat.warn(authoritativeMNMessage);
+                throw new NotAuthorized(notAuthorizedCode, authoritativeMNMessage);
+            }
+
+        } else {
+            for (ServiceFailure sf : exceptions) {
+                logMetacat.warn(
+                    "For request [" + request + "]: ServiceFailure raised:" + sf.getDescription(),
+                    sf);
+            }
+
+            // just use the first one
+            ServiceFailure sf = exceptions.get(0);
+            sf.setDetail_code(serviceFailureCode);
+            throw sf;
+        }
+    }
+
+    /**
+     * Does only localNode(CN)/CN authorization
+     *
+     * @param session User session to check
+     * @throws ServiceFailure When unable to check for authorization
+     * @throws NotAuthorized  When session is not authorized
+     */
+    public void doCNOnlyAuthorization(Session session) throws ServiceFailure, NotAuthorized {
+        if (session != null && session.getSubject() != null) {
+            logMetacat.debug(
+                "D1AuthHelper.doCNOnlyAuthorization - the session is " + session.getSubject()
+                    .getValue());
+        }
+        List<ServiceFailure> exceptions = new ArrayList<>();
+
+        try {
+            if (this.isLocalNodeAdmin(session, NodeType.CN)) {
+                return;
+            }
+        } catch (ServiceFailure e) {
+            exceptions.add(e);
+        }
+
+        try {
+            NodeList nodelist = this.getCNNodeList();
+            if (this.isCNAdmin(session, nodelist)) {
+                return;
+            }
+        } catch (ServiceFailure e) {
+            exceptions.add(e);
+        }
+
+        if (exceptions.isEmpty()) {
+            prepareAndThrowNotAuthorized(session, requestIdentifier, null, notAuthorizedCode);
         } else {
             // just use the first one
             ServiceFailure sf = exceptions.get(0);
@@ -412,32 +418,33 @@ public class D1AuthHelper {
      * @throws ServiceFailure When unable to check for authorization
      * @throws NotAuthorized  When session is not authorized
      */
-    public void doGetSysmetaAuthorization(Session session, SystemMetadata sysmeta, Permission permission) throws ServiceFailure, NotAuthorized
-    {      
-        if(session != null && session.getSubject() != null) {
-            logMetacat.debug("D1AuthHelper.doGetSysmetaAuthorization - the session is "+session.getSubject().getValue());
+    public void doGetSysmetaAuthorization(
+        Session session, SystemMetadata sysmeta, Permission permission)
+        throws ServiceFailure, NotAuthorized {
+        if (session != null && session.getSubject() != null) {
+            logMetacat.debug(
+                "D1AuthHelper.doGetSysmetaAuthorization - the session is " + session.getSubject()
+                    .getValue());
         }
         List<ServiceFailure> exceptions = new ArrayList<>();
-        // most efficient step first - uses materials passed in
+        // First check the given parameters
         if (this.isAuthorizedBySysMetaSubjects(session, sysmeta, permission)) {
             return;
         }
-        // next most efficient step: checks against local node document built via system properties 
+        // Then check against the local node document built via Metacat properties
         try {
             if (this.isLocalNodeAdmin(session, null)) {
                 return;
             }
-        }
-        catch(ServiceFailure e) {
+        } catch (ServiceFailure e) {
             exceptions.add(e);
         }
-        
-        
+
         try {
             NodeList nodelist = this.getCNNodeList();
-
-            // these all compare the session to the nodelist in some way
-            if (this.isAuthoritativeMNodeAdmin(session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
+            // Rhese all compare the session to the nodelist in some way
+            if (this.isAuthoritativeMNodeAdmin(
+                session, sysmeta.getAuthoritativeMemberNode(), nodelist)) {
                 return;
             }
             if (this.isCNAdmin(session, nodelist)) {
@@ -446,51 +453,53 @@ public class D1AuthHelper {
             if (this.isReplicaMNodeAdmin(session, sysmeta, nodelist)) {
                 return;
             }
-        }
-        catch (ServiceFailure e) {
+        } catch (ServiceFailure e) {
             exceptions.add(e);
         }
 
-        // this makes 1 or more calls to listSubjects, so is the most expensive
+        // Rhis makes 1 or more calls to listSubjects, so is the most expensive
         try {
             if (this.checkExpandedPermissions(session, sysmeta, permission)) {
                 return;
             }
-        }
-        catch (ServiceFailure e) {
+        } catch (ServiceFailure e) {
             exceptions.add(e);
         }
-        
-        if (exceptions.isEmpty()) { 
-            prepareAndThrowNotAuthorized(session,requestIdentifier, permission, notAuthorizedCode); 
+
+        if (exceptions.isEmpty()) {
+            prepareAndThrowNotAuthorized(session, requestIdentifier, permission, notAuthorizedCode);
         } else {
-             ServiceFailure sf = exceptions.get(0);
-             sf.setDetail_code(serviceFailureCode);
-             throw sf;
+            ServiceFailure sf = exceptions.get(0);
+            sf.setDetail_code(serviceFailureCode);
+            throw sf;
         }
     }
-    
- 
-    
-    
-    protected void prepareAndThrowNotAuthorized(Session session, Identifier pid, Permission permission, String detailCode) throws NotAuthorized {
-        
+
+    /**
+     * Format a 'NotAuthorized' exception
+     *
+     * @param session    Session that has been determined to be not authorized
+     * @param pid        Persistent identifier
+     * @param permission Permission level requested to check
+     * @param detailCode Detail code of exception
+     * @throws NotAuthorized
+     */
+    protected void prepareAndThrowNotAuthorized(
+        Session session, Identifier pid, Permission permission, String detailCode)
+        throws NotAuthorized {
+
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
         StringBuilder includedSubjects = new StringBuilder();
-        for (Subject s: sessionSubjects) {
+        for (Subject s : sessionSubjects) {
             includedSubjects.append(s.getValue()).append("; ");
-        } 
-        
-        String msg = String.format(
-                "%s not allowed on %s for subject[s]: %s",
-                    permission == null ? "Permission" : permission,
-                    pid == null ? null : pid.getValue(),
-                    includedSubjects
-                    );
-        logMetacat.warn(msg);
-        throw new NotAuthorized(detailCode, msg);   
-    }
+        }
 
+        String msg = String.format("%s not allowed on %s for subject[s]: %s",
+                                   permission == null ? "Permission" : permission,
+                                   pid == null ? null : pid.getValue(), includedSubjects);
+        logMetacat.warn(msg);
+        throw new NotAuthorized(detailCode, msg);
+    }
 
     /**
      * Compare all the session subjects against the expanded subjects (from listSubjects) of the
@@ -504,7 +513,6 @@ public class D1AuthHelper {
      */
     protected boolean checkExpandedPermissions(
         Session session, SystemMetadata sysmeta, Permission permission) throws ServiceFailure {
-
         // TODO: Is getting the subjectInfo of the rightsHolder really necessary? or do we need
         // to fix getSubjectInfo so we don't have to go back to the CNIdentity service to resolve
         // ownership? (This was put in to solve nested groups transitivity problems, to the best
@@ -514,7 +522,7 @@ public class D1AuthHelper {
             Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
             for (Subject s : sessionSubjects) {
                 if (s.getValue().equalsIgnoreCase("public")) {
-                    //assume the special subject 'public' isn't up for expansion
+                    // Assume the special subject 'public' isn't up for expansion
                     continue;
                 }
 
@@ -537,7 +545,6 @@ public class D1AuthHelper {
         return isAllowed;
     }
 
-
     /**
      * A centralized point for accessing the CN Nodelist, to make it easier to cache the nodelist in
      * the future, if it's seen as helpful performance-wise
@@ -546,27 +553,36 @@ public class D1AuthHelper {
      * @throws ServiceFailure When there is an issue checking for authorization
      */
     protected NodeList getCNNodeList() throws ServiceFailure {
-        if (cnList != null && cnList.getNodeList() != null && cnList.getNodeList().size() >0) {
+        if (cnList != null && cnList.getNodeList() != null && cnList.getNodeList().size() > 0) {
             logMetacat.debug("D1AuthHelper.getCNNodeList - got the cn list from the cache.");
             return cnList;
         } else {
-            // are we allowed to do this? only CNs are allowed
+            // Are we allowed to do this? only CNs are allowed
             try {
                 CNode cn = D1Client.getCN();
-                logMetacat.debug("D1AuthHelper.getCNNodeList - got CN instance and get the cn list from the network.");
+                logMetacat.debug(
+                    "D1AuthHelper.getCNNodeList - got CN instance and get the cn list from the "
+                        + "network.");
                 cnList = cn.listNodes();
-                return cnList; 
+                return cnList;
             } catch (NotImplemented e) {
-                logMetacat.error("Unexpected Error getting NodeList from getCNNodeList().  Got 'NotImplemented' from the service call!",e);
-                throw new ServiceFailure("","Could not get NodeList from the CN. got 'NotImplemented' from the service call!");
+                logMetacat.error(
+                    "Unexpected Error getting NodeList from getCNNodeList().  Got "
+                        + "'NotImplemented' from the service call!",
+                    e);
+                throw new ServiceFailure("",
+                                         "Could not get NodeList from the CN. got "
+                                             + "'NotImplemented' from the service call!");
             }
         }
-       
     }
 
     /**
      * Check if the given userSession is the member of the right holder group (if the right holder
      * is a group subject). If the right holder is not a group, it will be false of course.
+     *
+     * This method is public and static because it is used outside of D1NodeService & subclasses
+     * (PermissionController)
      *
      * @param rightHolder    the subject of the right holder.
      * @param sessionSubject the subject will be compared
@@ -577,98 +593,145 @@ public class D1AuthHelper {
      * @throws InvalidToken   Issue with credentials provided
      * @throws InvalidRequest Issue with the request
      */
-    public static boolean expandRightsHolder(Subject rightHolder, Subject sessionSubject) 
-        throws ServiceFailure, NotImplemented, InvalidRequest, NotAuthorized, InvalidToken 
-    {
-        // public and static because it is used outside of D1NodeService and subclasses - PermissionController
+    public static boolean expandRightsHolder(Subject rightHolder, Subject sessionSubject)
+        throws ServiceFailure, NotImplemented, InvalidRequest, NotAuthorized, InvalidToken {
         boolean is = false;
-        if(rightHolder != null && sessionSubject != null && rightHolder.getValue() != null && !rightHolder.getValue().trim().equals("") && sessionSubject.getValue() != null && !sessionSubject.getValue().trim().equals("")) {
+        if (rightHolder != null && sessionSubject != null && rightHolder.getValue() != null
+            && !rightHolder.getValue().trim().equals("") && sessionSubject.getValue() != null
+            && !sessionSubject.getValue().trim().equals("")) {
             CNode cn = D1Client.getCN();
-            logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - at the start of method: after getting the cn node and cn node is "+cn.getNodeBaseServiceUrl());
-            String query= rightHolder.getValue();
-            int start =0;
-            int count= 200;
+            logMetacat.debug("D1AuthHelper.expandRightHolder - at the start of method: after "
+                                 + "getting the cn node and cn node is "
+                                 + cn.getNodeBaseServiceUrl());
+            String query = rightHolder.getValue();
+            int start = 0;
+            int count = 200;
             String status = null;
             Session session = null;
             SubjectInfo subjects = cn.listSubjects(session, query, status, start, count);
 
-            while(subjects != null) {
-                logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - search the subject "+query+" in the cn and the returned result is not null");
+            while (subjects != null) {
+                logMetacat.debug("D1AuthHelper.expandRightHolder - search the subject " + query
+                                     + " in the cn and the returned result is not null");
                 List<Group> groups = subjects.getGroupList();
                 is = isInGroups(sessionSubject, rightHolder, groups);
-                if(is) {
+                if (is) {
                     //since we find it, return it.
                     return is;
                 } else {
                     //decide if we need to try the page query for another trying.
                     int sizeOfGroups = 0;
-                    if(groups != null) {
-                       sizeOfGroups  = groups.size();
+                    if (groups != null) {
+                        sizeOfGroups = groups.size();
                     }
                     List<Person> persons = subjects.getPersonList();
                     int sizeOfPersons = 0;
-                    if(persons != null) {
+                    if (persons != null) {
                         sizeOfPersons = persons.size();
                     }
-                    int totalSize = sizeOfGroups+sizeOfPersons;
-                    //logMetacat.debug("D1NodeService.expandRightHolder - search the subject "+query+" in the cn and the size of return result is "+totalSize);
-                   //we can't find the target on the first query, maybe query again.
-                    if(totalSize == count) {
-                        start = start+count;
-                        logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - search the subject "+query+" in the cn and the size of return result equals the count "+totalSize+" .And we didn't find the target in the this query. So we have to use the page query with the start number "+start);
+                    int totalSize = sizeOfGroups + sizeOfPersons;
+                    //logMetacat.debug("D1NodeService.expandRightHolder - search the subject
+                    // "+query+" in the cn and the size of return result is "+totalSize);
+                    //we can't find the target on the first query, maybe query again.
+                    if (totalSize == count) {
+                        start = start + count;
+                        logMetacat.debug(
+                            "D1AuthHelper.expandRightHolder - search the subject " + query
+                                + " in the cn and the size of return result equals the count "
+                                + totalSize
+                                + " .And we didn't find the target in the this query. So we have "
+                                + "to use the page query with the start number " + start);
                         subjects = cn.listSubjects(session, query, status, start, count);
-                    } else if (totalSize < count){
-                        logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - we are already at the end of the returned result since the size of returned results "+totalSize+
-                            " is less than the count "+count+". So we have to break the loop and finish the try.");
+                    } else if (totalSize < count) {
+                        logMetacat.debug("D1AuthHelper.expandRightHolder - we are already at the "
+                                             + "end of the returned result since the size of "
+                                             + "returned results " + totalSize
+                                             + " is less than the count " + count
+                                             + ". So we have to break the loop and finish the try"
+                                             + ".");
                         break;
-                    } else if (totalSize >count) {
-                        logMetacat.warn("D1AuthorizationDelegate.expandRightHolder - Something is wrong on the implementation of the method listSubject since the size of returned results "+totalSize+
-                                " is greater than the count "+count+". So we have to break the loop and finish the try.");
+                    } else if (totalSize > count) {
+                        logMetacat.warn("D1AuthHelper.expandRightHolder - Something is wrong on "
+                                            + "the implementation of the method listSubject since"
+                                            + " the size of" + " returned results " + totalSize
+                                            + " is greater than the count " + count
+                                            + ". So we have to break the loop and finish the try.");
                         break;
                     }
                 }
-                
-            } 
-            //logMetacat.debug("D1NodeService.expandRightHolder - search the subject "+query+" in the cn and the returned result is null");
-            if(!is) {
-                logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - We can NOT find any member in the group "+query+" (if it is a group) matches the user "+sessionSubject.getValue());
+
+            }
+            //logMetacat.debug("D1NodeService.expandRightHolder - search the subject "+query+" in
+            // the cn and the returned result is null");
+            if (!is) {
+                logMetacat.debug(
+                    "D1AuthHelper.expandRightHolder - We can NOT find any member in " + "the group "
+                        + query + " (if it is a group) matches the user "
+                        + sessionSubject.getValue());
             }
         } else {
-            logMetacat.debug("D1AuthorizationDelegate.expandRightHolder - We can't determine if the use subject is a member of the right holder group since one of them is null or blank");
+            logMetacat.debug("D1AuthHelper.expandRightHolder - We can't determine if the use "
+                                 + "subject is a member of the right holder group since one of "
+                                 + "them is null or blank");
         }
-       
+
         return is;
     }
-    
-    /*
+
+    /**
      * If the given useSession is a member of a group which is in the given list of groups and
      * has the name of rightHolder.
+     *
+     * @param userSession User session to check
+     * @param rightHolder Expected rightHolder
+     * @param groups List of groups to check
+     * @return True if session subject is found in the group
      */
-    private static boolean isInGroups(Subject userSession, Subject rightHolder, List<Group> groups) {
+    private static boolean isInGroups(
+        Subject userSession, Subject rightHolder, List<Group> groups) {
         boolean is = false;
-        if(groups != null) {
-            logMetacat.debug("D1NodeService.isInGroups -  the given groups' (the returned result including groups) size is "+groups.size());
-            for(Group group : groups) {
-                //logMetacat.debug("D1NodeService.expandRightHolder - group has the subject "+group.getSubject().getValue());
-                if(group != null && group.getSubject() != null && group.getSubject().equals(rightHolder)) {
-                    logMetacat.debug("D1NodeService.isInGroups - there is a group in the list having the subject "+group.getSubject().getValue()+" which matches the right holder's subject "+rightHolder.getValue());
+        if (groups != null) {
+            logMetacat.debug(
+                "D1AuthHelper.isInGroups -  the given groups' (the returned result including "
+                    + "groups) size is " + groups.size());
+            for (Group group : groups) {
+                Subject groupSubject = group.getSubject();
+                String groupSubjectValue = group.getSubject().getValue();
+                if (group != null && groupSubject != null && groupSubject.equals(rightHolder)) {
+                    logMetacat.debug(
+                        "D1AuthHelper.isInGroups - there is a group in the list having the "
+                            + "subject " + groupSubjectValue
+                            + " which matches the right holder's subject "
+                            + rightHolder.getValue());
                     List<Subject> members = group.getHasMemberList();
-                    if(members != null ){
-                        logMetacat.debug("D1NodeService.isInGroups - the group "+group.getSubject().getValue()+" in the cn has members");
-                        for(Subject member : members) {
-                            logMetacat.debug("D1NodeService.isInGroups - compare the member "+member.getValue()+" with the user "+userSession.getValue());
-                            if(member.getValue() != null && !member.getValue().trim().equals("") && userSession.getValue() != null && member.getValue().equals(userSession.getValue())) {
-                                logMetacat.debug("D1NodeService.isInGroups - Find it! The member "+member.getValue()+" in the group "+group.getSubject().getValue()+" matches the user "+userSession.getValue());
+                    if (members != null) {
+                        logMetacat.debug("D1AuthHelper.isInGroups - the group " + groupSubjectValue
+                                             + " in the cn has members");
+                        for (Subject member : members) {
+                            String memberValue = member.getValue();
+                            String userSessionValue = userSession.getValue();
+                            logMetacat.debug(
+                                "D1AuthHelper.isInGroups - compare the member " + memberValue
+                                    + " with the user " + userSessionValue);
+                            if (memberValue != null && !memberValue.isBlank() && memberValue.equals(
+                                userSessionValue)) {
+                                logMetacat.debug(
+                                    "D1AuthHelper.isInGroups - Find it! The member " + memberValue
+                                        + " in the group " + groupSubjectValue
+                                        + " matches the user " + userSessionValue);
                                 is = true;
                                 return is;
                             }
                         }
                     }
-                    break;//we found the group but can't find the member matches the user. so break it.
+                    // We found the group but can't find that the member matches the user.
+                    break;
                 }
             }
         } else {
-            logMetacat.debug("D1NodeService.isInGroups -  the given group is null (the returned result does NOT have a group");
+            logMetacat.debug(
+                "D1AuthHelper.isInGroups - The given group is null (the returned result does "
+                    + "NOT have a group");
         }
         return is;
     }
@@ -698,8 +761,6 @@ public class D1AuthHelper {
     public boolean isLocalCNAdmin(Session session) throws ServiceFailure {
         return isLocalNodeAdmin(session, NodeType.CN);
     }
-
-    // Protected Methods & Implementations
 
     /**
      * Checks Metacat properties representing the local Node document for matching Node.subjects.
@@ -780,9 +841,8 @@ public class D1AuthHelper {
      */
     protected boolean isAuthorizedBySysMetaSubjects(
         Session session, SystemMetadata sysmeta, Permission permission) {
-
-        // get the subject[s] from the session
-        // defer to the shared util for recursively compiling the subjects   
+        // Get the subject[s] from the session
+        // Defer to the shared util for recursively compiling the subjects
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
 
         if (logMetacat.isDebugEnabled()) {
@@ -806,7 +866,8 @@ public class D1AuthHelper {
      * @param nodelist List of relevant nodes to check
      * @return True if it is a replica mn node admin
      */
-    protected boolean isReplicaMNodeAdmin(Session session, SystemMetadata sysmeta, NodeList nodelist) {
+    protected boolean isReplicaMNodeAdmin(
+        Session session, SystemMetadata sysmeta, NodeList nodelist) {
 
         boolean isAuthorized = false;
 
@@ -814,24 +875,24 @@ public class D1AuthHelper {
         List<Replica> replicaList = sysmeta.getReplicaList();
         NodeReference replicaNodeRef;
 
-        if  ( replicaList != null && subject != null ) {
-            // get the list of nodes with a matching node subject
+        if (replicaList != null && subject != null) {
+            // Get the list of nodes with a matching node subject
             Set<Node> nodeListBySubject = NodelistUtil.selectNode(nodelist, subject);
 
             if (nodeListBySubject.size() > 0) {
-                // compare node ids to replica node ids
-                outer: 
-                    for (Replica replica : replicaList) {
-                        replicaNodeRef = replica.getReplicaMemberNode();
+                // Compare node ids to replica node ids
+                outer:
+                for (Replica replica : replicaList) {
+                    replicaNodeRef = replica.getReplicaMemberNode();
 
-                        for (Node node : nodeListBySubject) {
-                            if (node.getIdentifier().equals(replicaNodeRef)) {
-                                // node id via session subject matches a replica node
-                                isAuthorized = true;
-                                break outer;
-                            }
+                    for (Node node : nodeListBySubject) {
+                        if (node.getIdentifier().equals(replicaNodeRef)) {
+                            // node id via session subject matches a replica node
+                            isAuthorized = true;
+                            break outer;
                         }
                     }
+                }
             }
         }
         return isAuthorized;
@@ -843,13 +904,14 @@ public class D1AuthHelper {
      * According to the DataONE documentation, the authoritative member node has all the rights of
      * the *rightsHolder*. Any null parameter will result in return of false
      *
-     * @param session User session to check
+     * @param session            User session to check
      * @param authoritativeMNode The authoritativeMNode reference
-     * @param nodelist List of relevant nodes to check
+     * @param nodelist           List of relevant nodes to check
      * @return True if it is an authoritative MNode admin
      */
-    protected boolean isAuthoritativeMNodeAdmin(Session session, NodeReference authoritativeMNode, NodeList nodelist) { 
-        
+    protected boolean isAuthoritativeMNodeAdmin(
+        Session session, NodeReference authoritativeMNode, NodeList nodelist) {
+
         boolean allowed = false;
 
         if (session == null) {
@@ -861,7 +923,6 @@ public class D1AuthHelper {
         if (nodelist == null) {
             return false;
         }
-        
 
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
         if (sessionSubjects == null) {
@@ -873,20 +934,21 @@ public class D1AuthHelper {
         }
 
         List<Subject> nodeSubjects = node.getSubjectList();
-        if(nodeSubjects != null) {
+        if (nodeSubjects != null) {
 
-            // check if the session subject is in the node subject list
-          outer:
+            // Check if the session subject is in the node subject list
+            outer:
             for (Subject nodeSubject : nodeSubjects) {
                 for (Subject sessionSubject : sessionSubjects) {
-                    logMetacat.debug("D1NodeService.isAuthoritativeMNodeAdmin(), comparing subjects: " +
-                            nodeSubject.getValue() + " and " + sessionSubject.getValue());
-                    if ( nodeSubject != null && nodeSubject.equals(sessionSubject) ) {
+                    logMetacat.debug(
+                        "D1NodeService.isAuthoritativeMNodeAdmin(), comparing subjects: "
+                            + nodeSubject.getValue() + " and " + sessionSubject.getValue());
+                    if (nodeSubject != null && nodeSubject.equals(sessionSubject)) {
                         allowed = true; // subject of session == target node subject
                         break outer;
                     }
                 }
-            }              
+            }
         }
         return allowed;
     }
@@ -899,10 +961,8 @@ public class D1AuthHelper {
      * @return True if session subject is a CN admin
      */
     protected boolean isCNAdmin(Session session, NodeList nodelist) {
-
+        logMetacat.debug("D1NodeService.isCNAdmin - The beginning");
         boolean allowed = false;
-
-        logMetacat.debug("D1NodeService.isCNAdmin - the beginning");
 
         if (session == null || session.getSubject() == null) {
             return false;
@@ -910,46 +970,47 @@ public class D1AuthHelper {
         if (nodelist == null) {
             return false;
         }
-        
-        List<Node> nodes = nodelist.getNodeList();
 
+        List<Node> nodes = nodelist.getNodeList();
         if (nodes == null || nodes.size() == 0) {
             return false;
         }
-       
+
         Set<Subject> sessionSubjects = AuthUtils.authorizedClientSubjects(session);
-        // find the node in the node list
-        search: 
-            for ( Node node : nodes ) {
+        // Find the node in the node list
+        search:
+        for (Node node : nodes) {
 
-                NodeReference nodeReference = node.getIdentifier();
-                if (logMetacat.isDebugEnabled()) {
-                    logMetacat.debug("In isCNAdmin(), a Node reference from the CN node list is: " + nodeReference.getValue());
-                }
+            NodeReference nodeReference = node.getIdentifier();
+            if (logMetacat.isDebugEnabled()) {
+                logMetacat.debug("In isCNAdmin(), a Node reference from the CN node list is: "
+                                     + nodeReference.getValue());
+            }
 
-                if (node.getType() == NodeType.CN) {
-                    List<Subject> nodeSubjects = node.getSubjectList();
+            if (node.getType() == NodeType.CN) {
+                List<Subject> nodeSubjects = node.getSubjectList();
 
-                    // check if the session subject is in the node subject list
-                    for (Subject nodeSubject : nodeSubjects) {
-                        if(sessionSubjects != null) {
-                            for (Subject subject : sessionSubjects) {
-                                if (logMetacat.isDebugEnabled()) {
-                                    logMetacat.debug("In isCNAdmin(), comparing subjects: " +
-                                            nodeSubject.getValue() + " and the user " + subject.getValue());
-                                }
-                                if ( nodeSubject.equals(subject) ) {
-                                    allowed = true; // subject of session == target node subject
-                                    break search;
-                                }
+                // Check if the session subject is in the node subject list
+                for (Subject nodeSubject : nodeSubjects) {
+                    if (sessionSubjects != null) {
+                        for (Subject subject : sessionSubjects) {
+                            if (logMetacat.isDebugEnabled()) {
+                                logMetacat.debug(
+                                    "In isCNAdmin(), comparing subjects: " + nodeSubject.getValue()
+                                        + " and the user " + subject.getValue());
+                            }
+                            if (nodeSubject.equals(subject)) {
+                                allowed = true; // subject of session == target node subject
+                                break search;
                             }
                         }
-                        
-                    }              
+                    }
+
                 }
             }
+        }
         if (logMetacat.isDebugEnabled()) {
-            logMetacat.debug("D1NodeService.isCNAdmin. Is it a cn admin? "+allowed);
+            logMetacat.debug("D1NodeService.isCNAdmin. Is it a cn admin? " + allowed);
         }
         return allowed;
     }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -200,10 +200,7 @@ public class D1AuthHelperTest {
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
-            CNode mockCN = getMockCN(null);
-
-            // .getCN() makes a network call
-            mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
+            initMockCN(null, mockD1Client);
 
             assertTrue("D1AuthHelper.expandRightsHolder should return true",
                        D1AuthHelper.expandRightsHolder(rhgSubject,
@@ -221,10 +218,7 @@ public class D1AuthHelperTest {
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
-            CNode mockCN = getMockCN(null);
-
-            // .getCN() makes a network call
-            mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
+            initMockCN(null, mockD1Client);
 
             Subject nonGroupSubject = new Subject();
             nonGroupSubject.setValue("notRightHolderGroupSubject");
@@ -245,10 +239,7 @@ public class D1AuthHelperTest {
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
-            CNode mockCN = getMockCN(null);
-
-            // .getCN() makes a network call
-            mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
+            initMockCN(null, mockD1Client);
 
             assertFalse("D1AuthHelper.expandRightsHolder should return false, the subject is not "
                             + "part of the member list.",
@@ -268,10 +259,7 @@ public class D1AuthHelperTest {
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Create an empty member list to add to the MockCN in the rightsHolder group
             List<Subject> hasMemberList = new ArrayList<>();
-            CNode mockCN = getMockCN(hasMemberList);
-
-            // .getCN() makes a network call
-            mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
+            initMockCN(hasMemberList, mockD1Client);
 
             assertFalse(
                 "D1AuthHelper.expandRightsHolder should return false, there are no members",
@@ -674,10 +662,8 @@ public class D1AuthHelperTest {
         return sysmeta;
     }
 
-    /**
-     * Get a mockCN that contains the given member list as part of the rightsHolder group
-     */
-    private CNode getMockCN(List<Subject> subjectMemberList) throws Exception {
+    private void initMockCN(List<Subject> subjectMemberList,
+                             MockedStatic<D1Client> mockD1Client) throws Exception {
         // Create a member list, to be added to the group
         List<Subject> hasMemberList;
         if (subjectMemberList == null) {
@@ -702,7 +688,8 @@ public class D1AuthHelperTest {
         when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
             .thenReturn(mockSInfo);
 
-        return mockCN;
+        // .getCN() makes a network call
+        mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
     }
 
 }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -199,16 +199,8 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Get a default rightsHolderGroup list
-            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
-
-            SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
-
-            CNode mockCN = Mockito.mock(CNode.class);
-            // .listSubjects(...) makes a network call
-            when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
-                .thenReturn(mockSInfo);
+            // Get a mockCN with the default member list
+            CNode mockCN = getMockCN(null);
 
             // .getCN() makes a network call
             mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
@@ -228,16 +220,8 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Get a default rightsHolderGroup list
-            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
-
-            SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
-
-            CNode mockCN = Mockito.mock(CNode.class);
-            // .listSubjects(...) makes a network call
-            when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
-                .thenReturn(mockSInfo);
+            // Get a mockCN with the default member list
+            CNode mockCN = getMockCN(null);
 
             // .getCN() makes a network call
             mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
@@ -260,16 +244,8 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Get a default rightsHolderGroup list
-            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
-
-            SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
-
-            CNode mockCN = Mockito.mock(CNode.class);
-            // .listSubjects(...) makes a network call
-            when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
-                .thenReturn(mockSInfo);
+            // Get a mockCN with the default member list
+            CNode mockCN = getMockCN(null);
 
             // .getCN() makes a network call
             mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
@@ -290,17 +266,9 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create an empty member list, to be added to the group
+            // Create an empty member list to add to the MockCN in the rightsHolder group
             List<Subject> hasMemberList = new ArrayList<>();
-            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(hasMemberList);
-
-            SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
-
-            CNode mockCN = Mockito.mock(CNode.class);
-            // .listSubjects(...) makes a network call
-            when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
-                .thenReturn(mockSInfo);
+            CNode mockCN = getMockCN(hasMemberList);
 
             // .getCN() makes a network call
             mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
@@ -707,9 +675,9 @@ public class D1AuthHelperTest {
     }
 
     /**
-     * Get a rightsHolderGroup, if null is supplied default values will be used.
+     * Get a mockCN that contains the given member list as part of the rightsHolder group
      */
-    private List<Group> getGenericRightsHolderGroup(List<Subject> subjectMemberList) {
+    private CNode getMockCN(List<Subject> subjectMemberList) throws Exception {
         // Create a member list, to be added to the group
         List<Subject> hasMemberList;
         if (subjectMemberList == null) {
@@ -726,7 +694,15 @@ public class D1AuthHelperTest {
         List<Group> groupList = new ArrayList<>();
         groupList.add(rightsHolderGroup);
 
-        return groupList;
+        SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
+        when(mockSInfo.getGroupList()).thenReturn(groupList);
+
+        CNode mockCN = Mockito.mock(CNode.class);
+        // .listSubjects(...) makes a network call
+        when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
+            .thenReturn(mockSInfo);
+
+        return mockCN;
     }
 
 }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -167,6 +167,66 @@ public class D1AuthHelperTest {
     }
 
     /**
+     * Confirm that doIsAuthorized authorizes a Metacat admin
+     */
+    @Test
+    public void testDoIsAuthorized_metacatAdmin() throws Exception {
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+
+        Session sessionMetacatAdmin = new Session();
+        sessionMetacatAdmin.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+        try {
+            authDelMock.doIsAuthorized(sessionMetacatAdmin, sysmetaEdited, Permission.CHANGE_PERMISSION);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Confirm that doIsAuthorized authorizes a CN admin
+     */
+    @Test
+    public void testDoIsAuthorized_cnAdmin() throws Exception {
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+
+        Session sessionCnAdmin = new Session();
+        sessionCnAdmin.setSubject(
+            TypeFactory.buildSubject("cn1Subject"));
+
+        try {
+            authDelMock.doIsAuthorized(sessionCnAdmin, sysmetaEdited, Permission.CHANGE_PERMISSION);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Confirm that doIsAuthorized authorizes a local node admin
+     */
+    @Test
+    public void testDoIsAuthorized_localNodeAdmin() throws Exception {
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+
+        Session sessionLocalNodeAdmin = new Session();
+        sessionLocalNodeAdmin.setSubject(
+            TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
+
+        try {
+            authDelMock.doIsAuthorized(sessionLocalNodeAdmin, sysmetaEdited, Permission.CHANGE_PERMISSION);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
      * Confirm that doUpdateAuth does not throw exception with approved 'authoritativeMemberNode'
      * value on sysmeta object.
      */

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -121,6 +121,29 @@ public class D1AuthHelperTest {
         return sysmeta;
     }
 
+    /**
+     * Get a rightsHolderGroup, if null is supplied default values will be used.
+     */
+    private List<Group> getGenericRightsHolderGroup(List<Subject> subjectMemberList) {
+        // Create a member list, to be added to the group
+        List<Subject> hasMemberList;
+        if (subjectMemberList == null) {
+            hasMemberList = new ArrayList<>();
+            Subject testGroupMember = new Subject();
+            testGroupMember.setValue("testGroupMember");
+            hasMemberList.add(testGroupMember);        // Bogus value
+            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
+        } else {
+            hasMemberList = subjectMemberList;
+        }
+        // Add member list to the rightsHolderGroup, which is set up before every test
+        rightsHolderGroup.setHasMemberList(hasMemberList);
+        List<Group> groupList = new ArrayList<>();
+        groupList.add(rightsHolderGroup);
+
+        return groupList;
+    }
+
     @Before
     public void setUp() throws Exception {
 
@@ -214,18 +237,11 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create a member list, to be added to the group
-            List<Subject> hasMemberList = new ArrayList<>();
-            Subject testGroupMember = new Subject();
-            testGroupMember.setValue("testGroupMember");
-            hasMemberList.add(testGroupMember);        // Bogus value
-            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
-            rightsHolderGroup.setHasMemberList(hasMemberList);
+            // Get a default rightsHolderGroup list
+            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
 
             SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            List<Group> groups = new ArrayList<>();
-            groups.add(rightsHolderGroup);
-            when(mockSInfo.getGroupList()).thenReturn(groups);
+            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
 
             CNode mockCN = Mockito.mock(CNode.class);
             // .listSubjects(...) makes a network call
@@ -250,18 +266,11 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create a member list, to be added to the group
-            List<Subject> hasMemberList = new ArrayList<>();
-            Subject testGroupMember = new Subject();
-            testGroupMember.setValue("testGroupMember");
-            hasMemberList.add(testGroupMember);        // Bogus value
-            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
-            rightsHolderGroup.setHasMemberList(hasMemberList);
+            // Get a default rightsHolderGroup list
+            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
 
             SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            List<Group> groups = new ArrayList<>();
-            groups.add(rightsHolderGroup);
-            when(mockSInfo.getGroupList()).thenReturn(groups);
+            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
 
             CNode mockCN = Mockito.mock(CNode.class);
             // .listSubjects(...) makes a network call
@@ -289,18 +298,11 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create a member list, to be added to the group
-            List<Subject> hasMemberList = new ArrayList<>();
-            Subject testGroupMember = new Subject();
-            testGroupMember.setValue("testGroupMember");
-            hasMemberList.add(testGroupMember);        // Bogus value
-            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
-            rightsHolderGroup.setHasMemberList(hasMemberList);
+            // Get a default rightsHolderGroup list
+            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(null);
 
             SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            List<Group> groups = new ArrayList<>();
-            groups.add(rightsHolderGroup);
-            when(mockSInfo.getGroupList()).thenReturn(groups);
+            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
 
             CNode mockCN = Mockito.mock(CNode.class);
             // .listSubjects(...) makes a network call
@@ -326,14 +328,12 @@ public class D1AuthHelperTest {
         // expandRightsHolder() is a public static method
         // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create a member list, to be added to the group
+            // Create an empty member list, to be added to the group
             List<Subject> hasMemberList = new ArrayList<>();
-            rightsHolderGroup.setHasMemberList(hasMemberList);
+            List<Group> testRightsHolderGroup = getGenericRightsHolderGroup(hasMemberList);
 
             SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
-            List<Group> groups = new ArrayList<>();
-            groups.add(rightsHolderGroup);
-            when(mockSInfo.getGroupList()).thenReturn(groups);
+            when(mockSInfo.getGroupList()).thenReturn(testRightsHolderGroup);
 
             CNode mockCN = Mockito.mock(CNode.class);
             // .listSubjects(...) makes a network call

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -196,8 +196,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testExpandRightsHolder() throws Exception {
-        // expandRightsHolder() is a public static method
-        // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
             initMockCN(null, mockD1Client);
@@ -214,8 +212,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testExpandRightsHolder_unauthorizedRightsHolderSubject() throws Exception {
-        // expandRightsHolder() is a public static method
-        // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
             initMockCN(null, mockD1Client);
@@ -235,8 +231,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testExpandRightsHolder_unauthorizedSessionSubject() throws Exception {
-        // expandRightsHolder() is a public static method
-        // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Get a mockCN with the default member list
             initMockCN(null, mockD1Client);
@@ -254,8 +248,6 @@ public class D1AuthHelperTest {
      */
     @Test
     public void testExpandRightsHolder_emptyHasMemberList() throws Exception {
-        // expandRightsHolder() is a public static method
-        // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
             // Create an empty member list to add to the MockCN in the rightsHolder group
             List<Subject> hasMemberList = new ArrayList<>();
@@ -662,6 +654,13 @@ public class D1AuthHelperTest {
         return sysmeta;
     }
 
+    /**
+     * Init a Mock CN that contains the given member list as part of the rightsHolder group
+     *
+     * @param subjectMemberList List of Subjects (members)
+     * @param mockD1Client Mock D1Client, whose class contains methods that make network calls
+     * @throws Exception
+     */
     private void initMockCN(List<Subject> subjectMemberList,
                              MockedStatic<D1Client> mockD1Client) throws Exception {
         // Create a member list, to be added to the group

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -283,7 +283,7 @@ public class D1AuthHelperTest {
     @Test
     public void testExpandRightsHolder_isInGroups_nullGroupMember() throws Exception {
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-            // Create a member list that with a null subject member to add to the MockCN in the
+            // Create a member list with a null subject member to add to the MockCN in the
             // rightsHolder group
             List<Subject> hasMemberList = new ArrayList<>();
             Subject testGroupMember = new Subject();

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -344,15 +344,28 @@ public class D1AuthHelperTest {
     }
 
     /**
-     * Confirm that isLocalNodeAdmin returns true with valid NodeAdmin subject
+     * Confirm that isLocalNodeAdmin returns true with valid NodeAdmin subject (cn)
      */
     @Test
-    public void testIsLocalNodeAdmin() throws ServiceFailure {
-        Session sessionLocalNodeAdmin = new Session();
-        sessionLocalNodeAdmin.setSubject(
+    public void testIsLocalNodeAdmin_cnAdmin() throws ServiceFailure {
+        Session sessionLocalCNodeAdmin = new Session();
+        sessionLocalCNodeAdmin.setSubject(
             TypeFactory.buildSubject("CN=urn:node:METACAT1,DC=dataone,DC=org"));
 
-        boolean isLocalCnNodeAdmin = authDel.isLocalNodeAdmin(sessionLocalNodeAdmin, null);
+        boolean isLocalCnNodeAdmin = authDel.isLocalNodeAdmin(sessionLocalCNodeAdmin, null);
+        assertTrue(isLocalCnNodeAdmin);
+    }
+
+    /**
+     * Confirm that isLocalNodeAdmin returns true with a Metacat admin
+     */
+    @Test
+    public void testIsLocalNodeAdmin_metacatAdmin() throws ServiceFailure {
+        Session sessionMetacatAdmin = new Session();
+        sessionMetacatAdmin.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+        boolean isLocalCnNodeAdmin = authDel.isLocalNodeAdmin(sessionMetacatAdmin, null);
         assertTrue(isLocalCnNodeAdmin);
     }
 

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -111,7 +112,8 @@ public class D1AuthHelperTest {
         SystemMetadata sysmeta =
             TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
                                                    new ByteArrayInputStream(
-                                                       ("tra la la la la").getBytes("UTF-8")),
+                                                       ("tra la la la la").getBytes(
+                                                           StandardCharsets.UTF_8)),
                                                    "MD5",
                                                    TypeFactory.buildFormatIdentifier("text/csv"),
                                                    TypeFactory.buildSubject(
@@ -239,6 +241,11 @@ public class D1AuthHelperTest {
             assertTrue("D1AuthHelper.expandRightsHolder should return true",
                        D1AuthHelper.expandRightsHolder(group1Subject,
                                                   sysmeta.getSubmitter()));
+
+
+            assertTrue("D1AuthHelper.expandRightsHolder should return false",
+                       D1AuthHelper.expandRightsHolder(group1Subject,
+                                                       sysmeta.getSubmitter()));
         }
     }
 
@@ -246,7 +253,7 @@ public class D1AuthHelperTest {
      * Confirm that doIsAuthorized authorizes a Metacat admin
      */
     @Test
-    public void testDoIsAuthorized_metacatAdmin() throws Exception {
+    public void testDoIsAuthorized_metacatAdmin() {
         try {
             authDelMock.doIsAuthorized(metacatAdminSession, sysmeta, Permission.CHANGE_PERMISSION);
         } catch (Exception e) {
@@ -258,7 +265,7 @@ public class D1AuthHelperTest {
      * Confirm that doIsAuthorized authorizes a CN admin
      */
     @Test
-    public void testDoIsAuthorized_cnAdmin() throws Exception {
+    public void testDoIsAuthorized_cnAdmin() {
         try {
             authDelMock.doIsAuthorized(cn1CNSession, sysmeta, Permission.CHANGE_PERMISSION);
         } catch (Exception e) {
@@ -270,7 +277,7 @@ public class D1AuthHelperTest {
      * Confirm that doIsAuthorized authorizes a local node admin
      */
     @Test
-    public void testDoIsAuthorized_localNodeAdmin() throws Exception {
+    public void testDoIsAuthorized_localNodeAdmin() {
         try {
             authDelMock.doIsAuthorized(localNodeSession, sysmeta, Permission.CHANGE_PERMISSION);
         } catch (Exception e) {
@@ -323,7 +330,7 @@ public class D1AuthHelperTest {
      * value on sysmeta object.
      */
     @Test
-    public void testDoUpdateAuth() throws Exception {
+    public void testDoUpdateAuth() {
         try {
             authDelMock.doUpdateAuth(defaultSession, sysmeta, Permission.CHANGE_PERMISSION,
                                      TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
@@ -336,7 +343,7 @@ public class D1AuthHelperTest {
      * Confirm that doUpdateAuth authorizes a Metacat admin
      */
     @Test
-    public void testDoUpdateAuth_metacatAdmin() throws Exception {
+    public void testDoUpdateAuth_metacatAdmin() {
         try {
             authDelMock.doUpdateAuth(metacatAdminSession, sysmeta, Permission.CHANGE_PERMISSION,
                 TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -185,6 +185,27 @@ public class D1AuthHelperTest {
     }
 
     /**
+     * Confirm that doUpdateAuth authorizes a Metacat admin
+     */
+    @Test
+    public void testDoUpdateAuth_metacatAdmin() throws Exception {
+        SystemMetadata sysmetaEdited = getGenericSysmetaObject();
+        sysmetaEdited.setAuthoritativeMemberNode(
+            TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+
+        Session sessionMetacatAdmin = new Session();
+        sessionMetacatAdmin.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+        try {
+            authDelMock.doUpdateAuth(sessionMetacatAdmin, sysmetaEdited, Permission.CHANGE_PERMISSION,
+                TypeFactory.buildNodeReference("urn:node:unitTestAuthMN"));
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
      * Check that doUpdateAuth throws exception when 'authoritativeMemberNode' is not the same
      * as what is found in the sysmeta object.
      */
@@ -222,6 +243,18 @@ public class D1AuthHelperTest {
         sessionCnAdmin.setSubject(TypeFactory.buildSubject("notAFriend"));
 
         authDelMock.doCNOnlyAuthorization(sessionCnAdmin);
+    }
+
+    /**
+     * Confirm that 'doCNOnlyAuthorization' authorizes a metacat admin
+     */
+    @Test(expected = NotAuthorized.class)
+    public void testDoCNOnlyAuthorization_metacatAdmin() throws Exception {
+        Session sessionMetacatAdmin = new Session();
+        sessionMetacatAdmin.setSubject(
+            TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+        authDelMock.doCNOnlyAuthorization(sessionMetacatAdmin);
     }
 
     /**
@@ -376,6 +409,23 @@ public class D1AuthHelperTest {
     public void testDoGetSysmetaAuthorization() {
         try {
             authDel.doGetSysmetaAuthorization(session, sysmeta, Permission.WRITE);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+    }
+
+    /**
+     * Confirm doGetSysmetaAuthorization authorizes a Metacat admin
+     */
+    @Test
+    public void testDoGetSysmetaAuthorization_metacatAdmin() {
+        try {
+            Session sessionMetacatAdmin = new Session();
+            sessionMetacatAdmin.setSubject(
+                TypeFactory.buildSubject("http://orcid.org/0000-0002-6076-8092"));
+
+            authDel.doGetSysmetaAuthorization(sessionMetacatAdmin, sysmeta, Permission.WRITE);
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -199,37 +199,41 @@ public class D1AuthHelperTest {
         notAuthorizedSession.setSubject(TypeFactory.buildSubject("notAFriend"));
     }
 
-    // TODO: This test needs to be reviewed
-    // @Ignore("Not yet implemented...")
     /**
-     * Check expandRightsHolder returns true with approved subject
+     * Check expandRightsHolder returns true with approved subject, ex. the Session subject is a
+     * member of the rights holder group.
      */
     @Test
     public void testExpandRightsHolder() throws Exception {
-
+        // expandRightsHolder() is a public static method
+        // D1Client contains methods that make network calls, which is to be mocked
         try (MockedStatic<D1Client> mockD1Client = Mockito.mockStatic(D1Client.class)) {
-
+            // Create a new rights holder group
+            Group rightsHolderGroup = new Group();
+            // Add a new group subject
             Subject group1Subject = new Subject();
-            group1Subject.setValue("testGroupSubject");
-            Group group1 = new Group();
-            group1.setSubject(group1Subject);
+            group1Subject.setValue("testRightsHolderSubject");
+            rightsHolderGroup.setSubject(group1Subject);
 
+            // Create a member list, to be added to the group
             List<Subject> hasMemberList = new ArrayList<>();
             Subject testGroupMember = new Subject();
-            group1Subject.setValue("testGroupMember");
-            hasMemberList.add(testGroupMember);        // bogus value
-            hasMemberList.add(sysmeta.getSubmitter()); // the one that will match
-            group1.setHasMemberList(hasMemberList);
+            testGroupMember.setValue("testGroupMember");
+            hasMemberList.add(testGroupMember);        // Bogus value
+            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
+            rightsHolderGroup.setHasMemberList(hasMemberList);
 
             SubjectInfo mockSInfo = Mockito.mock(SubjectInfo.class);
             List<Group> groups = new ArrayList<>();
-            groups.add(group1);
+            groups.add(rightsHolderGroup);
             when(mockSInfo.getGroupList()).thenReturn(groups);
 
             CNode mockCN = Mockito.mock(CNode.class);
+            // .listSubjects(...) also makes a network call
             when(mockCN.listSubjects(eq(null), any(), eq(null), anyInt(), anyInt()))
                 .thenReturn(mockSInfo);
 
+            // .getCN() makes a network call
             mockD1Client.when(D1Client::getCN).thenReturn(mockCN);
 
             assertTrue("D1AuthHelper.expandRightsHolder should return true",

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -106,44 +106,6 @@ public class D1AuthHelperTest {
         nl.addNode(otherMN);
     }
 
-    /**
-     * Get a minimal SystemMetadata object with default values
-     */
-    private SystemMetadata getGenericSysmetaObject() throws Exception {
-        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
-            TypeFactory.buildIdentifier("dip"), new ByteArrayInputStream(
-                ("Test Sysmeta Content InputStream").getBytes(StandardCharsets.UTF_8)), "MD5",
-            TypeFactory.buildFormatIdentifier("text/csv"),
-            TypeFactory.buildSubject("submitterRightsHolder"));
-        AccessPolicy ap = new AccessPolicy();
-        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
-        sysmeta.setAccessPolicy(ap);
-        return sysmeta;
-    }
-
-    /**
-     * Get a rightsHolderGroup, if null is supplied default values will be used.
-     */
-    private List<Group> getGenericRightsHolderGroup(List<Subject> subjectMemberList) {
-        // Create a member list, to be added to the group
-        List<Subject> hasMemberList;
-        if (subjectMemberList == null) {
-            hasMemberList = new ArrayList<>();
-            Subject testGroupMember = new Subject();
-            testGroupMember.setValue("testGroupMember");
-            hasMemberList.add(testGroupMember);        // Bogus value
-            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
-        } else {
-            hasMemberList = subjectMemberList;
-        }
-        // Add member list to the rightsHolderGroup, which is set up before every test
-        rightsHolderGroup.setHasMemberList(hasMemberList);
-        List<Group> groupList = new ArrayList<>();
-        groupList.add(rightsHolderGroup);
-
-        return groupList;
-    }
-
     @Before
     public void setUp() throws Exception {
 
@@ -727,6 +689,44 @@ public class D1AuthHelperTest {
         Assert.assertFalse("null Session should not be authorized via sysmeta subjects",
                            authDel.isAuthorizedBySysMetaSubjects(null, sysmeta, Permission.READ));
 
+    }
+
+    /**
+     * Get a minimal SystemMetadata object with default values
+     */
+    private SystemMetadata getGenericSysmetaObject() throws Exception {
+        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
+            TypeFactory.buildIdentifier("dip"), new ByteArrayInputStream(
+                ("Test Sysmeta Content InputStream").getBytes(StandardCharsets.UTF_8)), "MD5",
+            TypeFactory.buildFormatIdentifier("text/csv"),
+            TypeFactory.buildSubject("submitterRightsHolder"));
+        AccessPolicy ap = new AccessPolicy();
+        ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
+        sysmeta.setAccessPolicy(ap);
+        return sysmeta;
+    }
+
+    /**
+     * Get a rightsHolderGroup, if null is supplied default values will be used.
+     */
+    private List<Group> getGenericRightsHolderGroup(List<Subject> subjectMemberList) {
+        // Create a member list, to be added to the group
+        List<Subject> hasMemberList;
+        if (subjectMemberList == null) {
+            hasMemberList = new ArrayList<>();
+            Subject testGroupMember = new Subject();
+            testGroupMember.setValue("testGroupMember");
+            hasMemberList.add(testGroupMember);        // Bogus value
+            hasMemberList.add(sysmeta.getSubmitter()); // The matching member
+        } else {
+            hasMemberList = subjectMemberList;
+        }
+        // Add member list to the rightsHolderGroup, which is set up before every test
+        rightsHolderGroup.setHasMemberList(hasMemberList);
+        List<Group> groupList = new ArrayList<>();
+        groupList.add(rightsHolderGroup);
+
+        return groupList;
     }
 
 }

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -41,6 +41,23 @@ import org.mockito.MockedStatic;
 public class D1AuthHelperTest {
 
     static NodeList nl;
+    D1AuthHelper authDel;
+    D1AuthHelper authDelMock;
+    Session defaultSession;
+    Session authMNSession;
+    Session otherMNSession;
+    Session replMNSession;
+    Session cn1CNSession;
+    Session nullSession;
+    Session missingSubjectSession;
+    Session emptySubjectSession;
+    Session metacatAdminSession;
+    Session metacatAdminOtherSession;
+    Session localNodeSession;
+    Session notAuthorizedSession;
+    SystemMetadata sysmeta;
+    Group rightsHolderGroup;
+    Subject rhgSubject;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -89,37 +106,15 @@ public class D1AuthHelperTest {
         nl.addNode(otherMN);
     }
 
-    D1AuthHelper authDel;
-    D1AuthHelper authDelMock;
-    Session defaultSession;
-    Session authMNSession;
-    Session otherMNSession;
-    Session replMNSession;
-    Session cn1CNSession;
-    Session nullSession;
-    Session missingSubjectSession;
-    Session emptySubjectSession;
-    Session metacatAdminSession;
-    Session metacatAdminOtherSession;
-    Session localNodeSession;
-    Session notAuthorizedSession;
-    SystemMetadata sysmeta;
-    Group rightsHolderGroup;
-    Subject rhgSubject;
-
     /**
      * Get a minimal SystemMetadata object with default values
      */
     private SystemMetadata getGenericSysmetaObject() throws Exception {
-        SystemMetadata sysmeta =
-            TypeFactory.buildMinimalSystemMetadata(TypeFactory.buildIdentifier("dip"),
-                                                   new ByteArrayInputStream(
-                                                       ("tra la la la la").getBytes(
-                                                           StandardCharsets.UTF_8)),
-                                                   "MD5",
-                                                   TypeFactory.buildFormatIdentifier("text/csv"),
-                                                   TypeFactory.buildSubject(
-                                                       "submitterRightsHolder"));
+        SystemMetadata sysmeta = TypeFactory.buildMinimalSystemMetadata(
+            TypeFactory.buildIdentifier("dip"), new ByteArrayInputStream(
+                ("Test Sysmeta Content InputStream").getBytes(StandardCharsets.UTF_8)), "MD5",
+            TypeFactory.buildFormatIdentifier("text/csv"),
+            TypeFactory.buildSubject("submitterRightsHolder"));
         AccessPolicy ap = new AccessPolicy();
         ap.addAllow(TypeFactory.buildAccessRule("eq1", Permission.CHANGE_PERMISSION));
         sysmeta.setAccessPolicy(ap);
@@ -247,7 +242,7 @@ public class D1AuthHelperTest {
     }
 
     /**
-     * Confirm that expandRightsHolder should return false when the suppled rightsHolder
+     * Confirm that expandRightsHolder should return false when the supplied rightsHolder
      * is not in the rightsHolderGroup.
      */
     @Test

--- a/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/D1AuthHelperTest.java
@@ -6,6 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.dataone.client.v2.CNode;
+import org.dataone.client.v2.itk.D1Client;
 import org.dataone.service.exceptions.NotAuthorized;
 import org.dataone.service.exceptions.ServiceFailure;
 import org.dataone.service.types.v1.AccessPolicy;
@@ -29,6 +31,7 @@ import org.junit.Test;
 
 import edu.ucsb.nceas.LeanTestUtils;
 import org.mockito.Mockito;
+import org.mockito.MockedStatic;
 
 public class D1AuthHelperTest {
 
@@ -192,11 +195,20 @@ public class D1AuthHelperTest {
         notAuthorizedSession.setSubject(TypeFactory.buildSubject("notAFriend"));
     }
 
-    // TODO: This test should be implemented when time permitting.
-    @Ignore("Not yet implemented...")
+    // TODO: This test needs to be reviewed
+    // @Ignore("Not yet implemented...")
+    /**
+     * Check expandRightsHolder returns true with approved subject
+     */
     @Test
-    public void testExpandRightsHolder() {
-        fail("Not yet implemented");
+    public void testExpandRightsHolder() throws Exception {
+        try (MockedStatic<D1AuthHelper> mockd1auth = Mockito.mockStatic(D1AuthHelper.class)) {
+            Mockito.when(D1AuthHelper.expandRightsHolder(sysmeta.getRightsHolder(),
+                                                         sysmeta.getSubmitter())).thenReturn(true);
+            boolean isRightsHolder = authDelMock.expandRightsHolder(sysmeta.getRightsHolder(),
+                                                  sysmeta.getSubmitter());
+            assertTrue(isRightsHolder);
+        }
     }
 
     /**


### PR DESCRIPTION
Greetings @artntek 

I have moved the logic to check for Metacat admin privileges from the `doAdminAuthorization` method to `isLocalNodeAdmin`.

The `isLocalNodeAdmin` is called by the 6 public methods defined in the javadoc used to check for authorization, so it looks like we should have adequate coverage now.

I have also added additional junit tests to check for Metacat admin privileges and cleaned up the test class (easier to follow now). Please let me know if you have any feedback. 

Note - We are missing an accurate test for the `expandRightsHolder` method. Can you please help  take a look?

**This PR addresses the following issue:** [Metacat admin privileges are not checked for all methods used for authorization](https://github.com/NCEAS/metacat/issues/1837)