### PR TITLE
Bug-1871: Sphinx Autodocs Compilation Failure

### DIFF
--- a/docs/user/metacat/source/authinterface.rst
+++ b/docs/user/metacat/source/authinterface.rst
@@ -9,6 +9,7 @@ authentication is no longer available. Registering for an ORCID is simple, pleas
 After signing up for an ORCID iD, you may use it as an admin identity when first configuring Metacat
 authentication settings. Note, your full ORCID iD includes `https://orcid.org/` not just the 16-digit
 ORCID iD:
+
   ex. http://orcid.org/0000-0001-2345-6789
 
 This ORCID iD provides admin privileges and authorization to all Metacat features.

--- a/docs/user/metacat/source/authinterface.rst
+++ b/docs/user/metacat/source/authinterface.rst
@@ -3,6 +3,7 @@ Metacat Authentication Mechanism
 
 Metacat only supports ORCID authentication for administrative users. File-based or LDAP
 authentication is no longer available. Registering for an ORCID is simple, please visit:
+
   http://orcid.org/
 
 After signing up for an ORCID iD, you may use it as an admin identity when first configuring Metacat

--- a/docs/user/metacat/source/conf.py
+++ b/docs/user/metacat/source/conf.py
@@ -116,7 +116,7 @@ sphinx_version = list(map(int, sphinx.__version__.split('.')[:2]))
 use_deprecated_style_script = sphinx_version < [7, 0]
 
 html_context = {
-    'use_style_script': use_deprecated_style_script
+    'use_deprecated_style_script': use_deprecated_style_script
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/user/metacat/source/conf.py
+++ b/docs/user/metacat/source/conf.py
@@ -106,7 +106,7 @@ pygments_style = 'sphinx'
 html_theme = 'metacatui'
 
 # When linking .CSS stylesheets with custom themes in sphinx versions < 7.0.0
-# the 'style' jinja variable is used (and marked for deprecation)
+# the 'style' variable is used (and marked for deprecation)
 #
 # Starting sphinx version > 7.0.0, 'styles' is used, which is not backwards
 # compatible - so we need to add python code here to determine the sphinx

--- a/docs/user/metacat/source/conf.py
+++ b/docs/user/metacat/source/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import sys, os, configparser, io
+import sphinx
 from itertools import chain
 
 #Read the release version from the metacat.properties file
@@ -103,6 +104,20 @@ pygments_style = 'sphinx'
 # Sphinx are currently 'default' and 'sphinxdoc'.
 #html_theme = 'default'
 html_theme = 'metacatui'
+
+# When linking .CSS stylesheets with custom themes in sphinx versions < 7.0.0
+# the 'style' jinja variable is used (and marked for deprecation)
+#
+# Starting sphinx version > 7.0.0, 'styles' is used, which is not backwards
+# compatible - so we need to add python code here to determine the sphinx
+# version, and then use the correct syntax to load the static .CSS stylesheets
+# (ex. metacatui.css)
+sphinx_version = list(map(int, sphinx.__version__.split('.')[:2]))
+use_deprecated_style_script = sphinx_version < [7, 0]
+
+html_context = {
+    'use_style_script': use_deprecated_style_script
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/user/metacat/source/index.rst
+++ b/docs/user/metacat/source/index.rst
@@ -102,8 +102,6 @@ Contents
    query-index
    themes
    authinterface
-   replication
-   harvester
    oaipmh
    event-logging
    sitemaps

--- a/docs/user/metacat/source/oaipmh.rst
+++ b/docs/user/metacat/source/oaipmh.rst
@@ -1,12 +1,8 @@
-----
+OAI Protocol for Metadata Harvesting
+====================================
 
 .. deprecated:: 3.0.0
     Harvesting metadata in Metacat through OAI-PMH standard is obsolete.
-
-----
-
-OAI Protocol for Metadata Harvesting
-====================================
 
 The Open Archives Initiative Protocol for Metadata Harvesting (`OAI-PMH`_) was first 
 developed in the late 1990's as a standard for harvesting metadata from 

--- a/docs/user/metacat/source/themes/metacatui/layout.html
+++ b/docs/user/metacat/source/themes/metacatui/layout.html
@@ -122,7 +122,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/bootstrap.min.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/font-awesome/css/font-awesome.min.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
-    {#- Conditional script insertion based on Sphinx version #}
+    {#- Conditional stylesheet insertion based on Sphinx version #}
     {% if use_deprecated_style_script %}
     <!-- Script to use if sphinx version < 7.0.0 (ex. 4.3.2 on Ubuntu 22.04 -->
       <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />

--- a/docs/user/metacat/source/themes/metacatui/layout.html
+++ b/docs/user/metacat/source/themes/metacatui/layout.html
@@ -122,7 +122,15 @@
     <link rel="stylesheet" href="{{ pathto('_static/bootstrap.min.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/font-awesome/css/font-awesome.min.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
+    {#- Conditional script insertion based on Sphinx version #}
+    {% if use_deprecated_style_script %}
+    <!-- Script to use if sphinx version < 7.0.0 (ex. 4.3.2 on Ubuntu 22.04 -->
+      <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    {% else %}
+    <!-- Script to use if sphinx version > 7.0.0 -->
+      <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
+    {% endif %}
+
     {%- if not embedded %}
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {

--- a/docs/user/metacat/source/themes/metacatui/layout.html
+++ b/docs/user/metacat/source/themes/metacatui/layout.html
@@ -124,10 +124,10 @@
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {#- Conditional stylesheet insertion based on Sphinx version #}
     {% if use_deprecated_style_script %}
-    <!-- Script to use if sphinx version < 7.0.0 (ex. 4.3.2 on Ubuntu 22.04 -->
+    <!-- Stylesheet to use if sphinx version < 7.0.0 (ex. 4.3.2 on Ubuntu 22.04 -->
       <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
     {% else %}
-    <!-- Script to use if sphinx version > 7.0.0 -->
+    <!-- Stylesheet to use if sphinx version > 7.0.0 -->
       <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
     {% endif %}
 


### PR DESCRIPTION
When linking .CSS stylesheets with custom themes in sphinx versions < `7.0.0`
the `style` variable is used, but is marked for deprecation.

Starting sphinx version > `7.0.0`, `style` has been deprecated, and `styles` is used. However, this is not backwards compatible.

This PR updates `conf.py`, which controls the templating process for the sphinx-generated admin docs, to check for the sphinx version and to create a html context config variable which is used in `layout.html` to determine which syntax to use to link the .CSS stylesheets.