### PR TITLE
Merge dev-2.19 to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,12 @@
     </properties>
     <repositories>
         <repository>
+            <id>Jibx Maven Repository</id>
+            <url>https://jibx.sourceforge.net/maven/</url>
+        </repository>
+        <repository>
             <id>dataone.org</id>
-            <url>http://maven.dataone.org</url>
+            <url>https://maven.dataone.org</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>


### PR DESCRIPTION
Use the jibx repository with the https protocal to fix an issue that the foresite-toolkit jar file cannot be downloaded.