### PR TITLE
Feature-1678: Doc Updates Part 4

### DIFF
--- a/docs/user/metacat/source/admin-api.rst
+++ b/docs/user/metacat/source/admin-api.rst
@@ -13,9 +13,9 @@ Indexing Objects
 
 - **Re-index all objects or index a single pid:**
 
- PUT /index/{pid1}``
+ PUT /index/{pid1}
 
- PUT /index?[all=true] | [&pid={pid}]``
+ PUT /index?[all=true] | [&pid={pid}]
 
  ::
 
@@ -32,9 +32,9 @@ Updating Metadata
 
 - **Update the metadata for objects identified by their identifiers:**
 
- PUT /identifiers/{pid1}``
+ PUT /identifiers/{pid1}
 
- PUT /identifiers[/]?[all=true] | [&pid={pid1}] | [&formatId={formatId1}]``
+ PUT /identifiers[/]?[all=true] | [&pid={pid1}] | [&formatId={formatId1}]
 
  ::
 

--- a/docs/user/metacat/source/dataone.rst
+++ b/docs/user/metacat/source/dataone.rst
@@ -316,8 +316,13 @@ or can be set using the `CNReplication.setReplicationPolicy`_ service.
 Generating DataONE System Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- **Note:** The following feature is not available in Metacat 3.0.0. If you are upgrading your Metacat
- from Metacat version 1.*, we recommend that you first upgrade to 2.19.0 before proceeding with generating DataONE System Metadata.
+ **Note:**
+
+ - The following feature is not available in Metacat 3.0.0. If you've installed Metacat v3.0.0, or
+   have upgraded to Metacat v3.0.0, please ignore this section.
+
+ - Reminder, if your current Metacat version is v1.*, please first upgrade to v2.19.0 before
+   proceeding with generating DataONE System Metadata.
 
 When a Metacat instance becomes a Member Node, System Metadata must be generated for the existing
 content. This can be invoked in the Replication configuration screen of the Metacat administration

--- a/docs/user/metacat/source/install.rst
+++ b/docs/user/metacat/source/install.rst
@@ -730,8 +730,6 @@ instructions for installing from source:
 
     cp <web_app_dir>/metacat <backup_dir>/metacat.<yyyymmdd>
     cp <web_app_dir>/metacat.war <backup_dir>/metacat.war.<yyyymmdd>
-    cp <web_app_dir>/metacat-index.war <backup_dir>/metacat-index.war.<yyyymmdd>
-    cp <web_app_dir>/metacatui.war <backup_dir>/metacatui.war.<yyyymmdd>
 
   **Warning**: Do not backup the files to the ``<web_app_dir>`` directory. Tomcat will
   try to run the backup copy as a service.
@@ -741,6 +739,8 @@ instructions for installing from source:
   ::
 
     sudo cp <metacat_package_dir>/metacat.war <tomcat_app_dir>
+    sudo cp <metacat_package_dir>/metacat-index.war <tomcat_app_dir>
+    sudo cp <metacat_package_dir>/metacatui.war <tomcat_app_dir>
 
   Note: Typically, Tomcat will look for its application files (WAR files) in the
   ``<tomcat_home>/webapps`` directory. Your instance of Tomcat may be configured to

--- a/docs/user/metacat/source/install.rst
+++ b/docs/user/metacat/source/install.rst
@@ -730,8 +730,10 @@ instructions for installing from source:
 
     cp <web_app_dir>/metacat <backup_dir>/metacat.<yyyymmdd>
     cp <web_app_dir>/metacat.war <backup_dir>/metacat.war.<yyyymmdd>
+    cp <web_app_dir>/metacat-index.war <backup_dir>/metacat-index.war.<yyyymmdd>
+    cp <web_app_dir>/metacatui.war <backup_dir>/metacatui.war.<yyyymmdd>
 
-  Warning: Do not backup the files to the ``<web_app_dir>`` directory.  Tomcat will
+  **Warning**: Do not backup the files to the ``<web_app_dir>`` directory. Tomcat will
   try to run the backup copy as a service.
 
 4. Copy the new Metacat WAR file in to the Tomcat applications directory: 


### PR DESCRIPTION
`admin-api.rst`
- Fixed typos (leftover backticks)

`install.rst`
- Suggested additional directories to backup

`dataone.rst`
- Revised section for generating system metadata to ignore if operator is at Metacat v3.0.0