### PR TITLE
Convert the objects without system metadata

### DIFF
--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -184,35 +184,40 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                     pid.setValue(finalId);
                                     SystemMetadata sysMeta =
                                         SystemMetadataManager.getInstance().get(pid);
-                                    Path path = resolve(sysMeta); // it may be null
-                                    if (sysMeta.getChecksum() != null) {
-                                        String checksum = sysMeta.getChecksum().getValue();
-                                        String algorithm =
-                                            sysMeta.getChecksum().getAlgorithm().toUpperCase();
-                                        logMetacat.debug("Trying to convert the storage to hashstore"
-                                                             + " for " + id + " with checksum: "
-                                                             + checksum + " algorithm: " + algorithm
-                                                             + " and file path(may be null): "
-                                                             + path.toString());
-                                        Future<?> future = executor.submit(() -> {
-                                            convert(path, finalId, sysMeta, checksum,
-                                                    algorithm, nonMatchingChecksumWriter,
-                                                    noSuchAlgorithmWriter, generalWriter,
-                                                    savingChecksumTableWriter);
-                                        });
-                                        futures.add(future);
-                                        if (futures.size() >= maxSetSize) {
-                                            //When it reaches the max size, we need to remove
-                                            // the complete futures from the set. So the set can
-                                            // be reused again. So we can avoid the issue of out of
-                                            // memory.
-                                            removeCompleteFuture(futures);
+                                    if (sysMeta != null) {
+                                        Path path = resolve(sysMeta); // it may be null
+                                        if (sysMeta.getChecksum() != null) {
+                                            String checksum = sysMeta.getChecksum().getValue();
+                                            String algorithm =
+                                                sysMeta.getChecksum().getAlgorithm().toUpperCase();
+                                            logMetacat.debug("Trying to convert the storage to hashstore"
+                                                                 + " for " + id + " with checksum: "
+                                                                 + checksum + " algorithm: " + algorithm
+                                                                 + " and file path(may be null): "
+                                                                 + path.toString());
+                                            Future<?> future = executor.submit(() -> {
+                                                convert(path, finalId, sysMeta, checksum,
+                                                        algorithm, nonMatchingChecksumWriter,
+                                                        noSuchAlgorithmWriter, generalWriter,
+                                                        savingChecksumTableWriter);
+                                            });
+                                            futures.add(future);
+                                            if (futures.size() >= maxSetSize) {
+                                                //When it reaches the max size, we need to remove
+                                                // the complete futures from the set. So the set can
+                                                // be reused again. So we can avoid the issue of out of
+                                                // memory.
+                                                removeCompleteFuture(futures);
+                                            }
+                                        } else {
+                                            logMetacat.error("There is no checksum info for id " + id +
+                                                                 " in the systemmetadata and Metacat "
+                                                                 + "cannot convert it to hashstore.");
+                                            writeToFile(id, noChecksumInSysmetaWriter);
                                         }
                                     } else {
-                                        logMetacat.error("There is no checksum info for id " + id +
-                                                            " in the systemmetadata and Metacat "
-                                                            + "cannot convert it to hashstore.");
-                                        writeToFile(id, noChecksumInSysmetaWriter);
+                                        logMetacat.debug("The id " + id + " hasn't been converted"
+                                                             + " to the DataONE identifier");
                                     }
                                 }
                             } catch (Exception e) {
@@ -298,14 +303,18 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
      * Run a query to select the list of candidate pid from the systemmetadata which will be
      * converted. If the pid exists in the checksums table, we consider it is in the hashstore and
      * wouldn't convert it. Both the checksums table and hashstore are introduced in 3.1.0.
+     * Also, it will pick up unsuccessfully converted docids to the dataone identifiers.
      * @return a ResultSet object which contains the list of identifiers:
      * @throws SQLException
      */
     protected ResultSet initCandidateList() throws SQLException {
         // Iterate the systemmetadata table
         String query =
-            "SELECT s.guid FROM systemmetadata s LEFT JOIN checksums c ON s.guid = c.guid WHERE "
-                + "c.guid IS NULL;";
+            "(WITH docid_rev (docid, rev) AS (SELECT docid, rev FROM xml_documents UNION SELECT "
+                + "docid, rev FROM  xml_revisions) SELECT CONCAT(d.docid, '.', d.rev) AS guid "
+                + "FROM docid_rev d LEFT JOIN identifier i ON d.docid=i.docid and d.rev=i.rev "
+                + "WHERE i.docid IS NULL) UNION (SELECT s.guid FROM systemmetadata s LEFT JOIN "
+                + "checksums c ON s.guid = c.guid WHERE c.guid IS NULL);";
         DBConnection dbConn = null;
         ResultSet rs = null;
         int serialNumber = -1;

--- a/src/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactory.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactory.java
@@ -574,8 +574,9 @@ public class SystemMetadataFactory {
                 if (file.exists()) {
                     return new FileInputStream(file);
                 } else {
-                    throw new FileNotFoundException("Can't find the object " + localId + " in the"
-                                                        + " Metacat legacy store.");
+                    throw new FileNotFoundException(
+                        "Can't find the object " + file.getAbsolutePath() + " in the"
+                            + " Metacat legacy store.");
                 }
             } else {
                 throw new FileNotFoundException("Can't find the object " + localId + " in the"
@@ -586,8 +587,8 @@ public class SystemMetadataFactory {
             if (file.exists()) {
                 return new FileInputStream(file);
             } else {
-                throw new FileNotFoundException("Can't find the object " + localId + " in the"
-                                                    + " Metacat legacy store.");
+                throw new FileNotFoundException("Can't find the object " + file.getAbsolutePath()
+                                                    + " in the Metacat legacy store.");
             }
         } else {
             throw new FileNotFoundException("Can't find the object " + localId + " in the"

--- a/src/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactory.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactory.java
@@ -2,6 +2,8 @@ package edu.ucsb.nceas.metacat.dataone;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -54,7 +56,6 @@ import edu.ucsb.nceas.metacat.client.InsufficientKarmaException;
 import edu.ucsb.nceas.metacat.properties.PropertyService;
 import edu.ucsb.nceas.metacat.shared.AccessException;
 import edu.ucsb.nceas.metacat.shared.HandlerException;
-import edu.ucsb.nceas.metacat.startup.MetacatInitializer;
 import edu.ucsb.nceas.metacat.systemmetadata.SystemMetadataManager;
 import edu.ucsb.nceas.metacat.util.DocumentUtil;
 import edu.ucsb.nceas.utilities.ParseLSIDException;
@@ -70,6 +71,26 @@ public class SystemMetadataFactory {
      * content
      */
     private static boolean updateExisting = true;
+    private static String legacyDataDir = null;
+    private static String legacyDocDir = null;
+    static {
+        try {
+            legacyDataDir = PropertyService.getProperty("application.datafilepath");
+            if (!legacyDataDir.endsWith("/")) {
+                legacyDataDir = legacyDataDir + "/";
+            }
+        } catch (PropertyNotFoundException e) {
+            logMetacat.error("Metacat can't find the property value of application.datafilepath");
+        }
+        try {
+            legacyDocDir = PropertyService.getProperty("application.documentfilepath");
+            if (!legacyDocDir.endsWith("/")) {
+                legacyDocDir = legacyDocDir + "/";
+            }
+        } catch (PropertyNotFoundException e) {
+            logMetacat.error("Metacat can't find the property value of application.documentfilepath");
+        }
+    }
 
 
     /**
@@ -151,17 +172,31 @@ public class SystemMetadataFactory {
 
         // for retrieving the actual object
         try (InputStream inputStream = MetacatHandler.read(identifier)) {
-         // create the checksum
+            // create the checksum
             String algorithm = PropertyService.getProperty("dataone.checksumAlgorithm.default");
             Checksum checksum = ChecksumUtil.checksum(inputStream, algorithm);
             logMetacat.debug("The checksum for " + localId + " is " + checksum.getValue());
             sysMeta.setChecksum(checksum);
+        } catch (McdbDocNotFoundException e) {
+            // try to read it from the legacy store
+            try (InputStream inputStream = readFileFromLegacyStore(identifier)) {
+                // create the checksum
+                String algorithm = PropertyService.getProperty("dataone.checksumAlgorithm.default");
+                Checksum checksum = ChecksumUtil.checksum(inputStream, algorithm);
+                logMetacat.debug("The checksum for " + localId + " is " + checksum.getValue());
+                sysMeta.setChecksum(checksum);
+            }
         }
 
         // set the size
         long fileSize = 0;
         try (InputStream inputStream = MetacatHandler.read(identifier)) {
             fileSize = length(inputStream);
+        } catch (McdbDocNotFoundException e) {
+            // Try to read from the legacy store
+            try (InputStream inputStream = readFileFromLegacyStore(identifier)) {
+                fileSize = length(inputStream);
+            }
         }
         sysMeta.setSize(BigInteger.valueOf(fileSize));
 
@@ -519,5 +554,45 @@ public class SystemMetadataFactory {
             length += chunkBytesRead;
         }
         return length;
+    }
+
+    /**
+     * This method is used for the HashStoreUpgrader class to read the object from the Metacat
+     * legacy store since the Hashtore hasn't been successfully converted.
+     * @param pid  the identifier the object
+     * @return the InputStream presentation of the object
+     */
+    protected static InputStream readFileFromLegacyStore(Identifier pid)
+        throws FileNotFoundException {
+        String localId = pid.getValue();
+        if (legacyDocDir != null) {
+            File file = new File(legacyDocDir + localId);
+            if (file.exists()) {
+                return new FileInputStream(file);
+            } else if (legacyDataDir != null) {
+                file = new File(legacyDataDir + localId);
+                if (file.exists()) {
+                    return new FileInputStream(file);
+                } else {
+                    throw new FileNotFoundException("Can't find the object " + localId + " in the"
+                                                        + " Metacat legacy store.");
+                }
+            } else {
+                throw new FileNotFoundException("Can't find the object " + localId + " in the"
+                                                    + " Metacat legacy store.");
+            }
+        } else if (legacyDataDir != null) {
+            File file = new File(legacyDataDir + localId);
+            if (file.exists()) {
+                return new FileInputStream(file);
+            } else {
+                throw new FileNotFoundException("Can't find the object " + localId + " in the"
+                                                    + " Metacat legacy store.");
+            }
+        } else {
+            throw new FileNotFoundException("Can't find the object " + localId + " in the"
+                                                + " Metacat legacy store since the its data and"
+                                                + " document root directories are null.");
+        }
     }
 }

--- a/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderTest.java
+++ b/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderTest.java
@@ -920,10 +920,13 @@ public class HashStoreUpgraderTest {
         System.out.print("the prefix is " + prefix);
         String id1 = prefix + "." + 1;
         String id2 = prefix + "." + 2;
+        String id3 = prefix + "." + 3;
         Identifier pid1 = new Identifier();
         pid1.setValue(id1);
         Identifier pid2 = new Identifier();
         pid2.setValue(id2);
+        Identifier pid3 = new Identifier();
+        pid3.setValue(id3);
         String user = "http://orcid.org/1234/4567";
         String docName = "eml";
         String docType = "https://eml.ecoinformatics.org/eml-2.2.0";
@@ -938,8 +941,12 @@ public class HashStoreUpgraderTest {
             // But there are no system metadata and identifier records for them
             DocumentImpl.registerDocument(docName, docType, dbConn, id1, user);
             DocumentImpl.registerDocument(docName, docType, dbConn, id2, user);
-            assertTrue("The xml_documents table should have the record " + id2,
+            DocumentImpl.registerDocument(docName, docType, dbConn, id3, user);
+            assertTrue("The xml_documents table should have the record " + id3,
                        IntegrationTestUtils.hasRecord("xml_documents", dbConn, " rev=? and docid like ?"
+                           , 3, prefix));
+            assertTrue("The xml_revisions table should have the record " + id2,
+                       IntegrationTestUtils.hasRecord("xml_revisions", dbConn, " rev=? and docid like ?"
                            , 2, prefix));
             assertTrue("The xml_revisions table should have the record " + id1,
                        IntegrationTestUtils.hasRecord("xml_revisions", dbConn, " rev=? and docid like ?"
@@ -951,6 +958,7 @@ public class HashStoreUpgraderTest {
             } catch (Exception e) {
                 assertTrue(e instanceof McdbDocNotFoundException);
             }
+            assertFalse(IdentifierManager.getInstance().mappingExists(id1));
             try {
                 IdentifierManager.getInstance().getGUID(prefix, 2);
                 fail("Test shouldn't reach here since " + id1 + " shouldn't exist in the "
@@ -958,9 +966,20 @@ public class HashStoreUpgraderTest {
             } catch (Exception e) {
                 assertTrue(e instanceof McdbDocNotFoundException);
             }
+            assertFalse(IdentifierManager.getInstance().mappingExists(id2));
+            try {
+                IdentifierManager.getInstance().getGUID(prefix, 3);
+                fail("Test shouldn't reach here since " + id1 + " shouldn't exist in the "
+                         + "identifer table");
+            } catch (Exception e) {
+                assertTrue(e instanceof McdbDocNotFoundException);
+            }
+            assertFalse(IdentifierManager.getInstance().mappingExists(id3));
             SystemMetadata systemMetadata = SystemMetadataManager.getInstance().get(pid1);
             assertNull(systemMetadata);
             systemMetadata = SystemMetadataManager.getInstance().get(pid2);
+            assertNull(systemMetadata);
+            systemMetadata = SystemMetadataManager.getInstance().get(pid3);
             assertNull(systemMetadata);
         } finally {
             DBConnectionPool.returnDBConnection(
@@ -970,29 +989,109 @@ public class HashStoreUpgraderTest {
         File file = new File(fileName);
         File dest1 = new File(documentPath + "/" + id1);
         File dest2 = new File(documentPath + "/" + id2);
+        File dest3 = new File(documentPath + "/" + id3);
         try {
             FileUtils.copyFile(file, dest1);
             FileUtils.copyFile(file, dest2);
+            FileUtils.copyFile(file, dest3);
             ResultSet resultSetMock = Mockito.mock(ResultSet.class);
-            // mock only having two next
-            Mockito.when(resultSetMock.getString(1)).thenReturn(id1).thenReturn(id2);
-            Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+            // mock only having three next
+            Mockito.when(resultSetMock.getString(1)).thenReturn(id1).thenReturn(id2).thenReturn(id3);
+            Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(true).thenReturn(true)
+                .thenReturn(false);
             // mock HashStoreUpgrader with the real methods
             HashStoreUpgrader upgrader = Mockito.mock(HashStoreUpgrader.class,
                 withSettings().useConstructor().defaultAnswer(CALLS_REAL_METHODS));
             // mock the initCandidate method
             Mockito.doReturn(resultSetMock).when(upgrader).initCandidateList();
             upgrader.upgrade();
+
+            // Check the results.
             File hashStoreRoot = new File(hashStorePath);
             assertTrue(hashStoreRoot.exists());
+            assertEquals(id1, IdentifierManager.getInstance().getGUID(prefix, 1));
+            assertTrue(IdentifierManager.getInstance().mappingExists(id1));
             SystemMetadata systemMetadata1 = SystemMetadataManager.getInstance().get(pid1);
             assertNotNull(systemMetadata1);
+            assertEquals(id1, systemMetadata1.getIdentifier().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata1.getOriginMemberNode().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata1.getAuthoritativeMemberNode().getValue());
+            assertEquals(id2, systemMetadata1.getObsoletedBy().getValue());
+            assertNull(systemMetadata1.getObsoletes());
+            assertEquals("MD5", systemMetadata1.getChecksum().getAlgorithm());
+            assertEquals(
+                "f4ea2d07db950873462a064937197b0f", systemMetadata1.getChecksum().getValue());
+            assertEquals(8724, systemMetadata1.getSize().intValue());
+            assertEquals(user, systemMetadata1.getRightsHolder().getValue());
+            assertEquals(user, systemMetadata1.getSubmitter().getValue());
+            assertEquals(docType, systemMetadata1.getFormatId().getValue());
+
+            assertEquals(id2, IdentifierManager.getInstance().getGUID(prefix, 2));
+            assertTrue(IdentifierManager.getInstance().mappingExists(id2));
             SystemMetadata systemMetadata2 = SystemMetadataManager.getInstance().get(pid2);
             assertNotNull(systemMetadata2);
+            assertEquals(id2, systemMetadata2.getIdentifier().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata2.getOriginMemberNode().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata2.getAuthoritativeMemberNode().getValue());
+            assertEquals(id1, systemMetadata2.getObsoletes().getValue());
+            assertEquals(id3, systemMetadata2.getObsoletedBy().getValue());
+            assertEquals("MD5", systemMetadata2.getChecksum().getAlgorithm());
+            assertEquals(
+                "f4ea2d07db950873462a064937197b0f", systemMetadata2.getChecksum().getValue());
+            assertEquals(8724, systemMetadata2.getSize().intValue());
+            assertEquals(user, systemMetadata2.getRightsHolder().getValue());
+            assertEquals(user, systemMetadata2.getSubmitter().getValue());
+            assertEquals(docType, systemMetadata2.getFormatId().getValue());
+
+            assertEquals(id3, IdentifierManager.getInstance().getGUID(prefix, 3));
+            assertTrue(IdentifierManager.getInstance().mappingExists(id3));
+            SystemMetadata systemMetadata3 = SystemMetadataManager.getInstance().get(pid3);
+            assertNotNull(systemMetadata3);
+            assertEquals(id3, systemMetadata3.getIdentifier().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata3.getOriginMemberNode().getValue());
+            assertEquals(
+                PropertyService.getProperty("dataone.nodeId"),
+                systemMetadata3.getAuthoritativeMemberNode().getValue());
+            assertEquals(id2, systemMetadata3.getObsoletes().getValue());
+            assertNull(systemMetadata3.getObsoletedBy());
+            assertEquals("MD5", systemMetadata3.getChecksum().getAlgorithm());
+            assertEquals(
+                "f4ea2d07db950873462a064937197b0f", systemMetadata3.getChecksum().getValue());
+            assertEquals(8724, systemMetadata3.getSize().intValue());
+            assertEquals(user, systemMetadata3.getRightsHolder().getValue());
+            assertEquals(user, systemMetadata3.getSubmitter().getValue());
+            assertEquals(docType, systemMetadata3.getFormatId().getValue());
+
             assertNotNull(MetacatInitializer.getStorage().retrieveObject(pid1));
             assertNotNull(MetacatInitializer.getStorage().retrieveMetadata(pid1));
             assertNotNull(MetacatInitializer.getStorage().retrieveObject(pid2));
             assertNotNull(MetacatInitializer.getStorage().retrieveMetadata(pid2));
+            assertNotNull(MetacatInitializer.getStorage().retrieveObject(pid3));
+            assertNotNull(MetacatInitializer.getStorage().retrieveMetadata(pid3));
+
+            SystemMetadata sysmetaFromHash =
+                TypeMarshaller.unmarshalTypeFromStream(SystemMetadata.class,
+                                                                     MetacatInitializer.getStorage()
+                                                                         .retrieveMetadata(pid1));
+            compareValues(systemMetadata1, sysmetaFromHash);
+            sysmetaFromHash = TypeMarshaller.unmarshalTypeFromStream(SystemMetadata.class,
+                                                                     MetacatInitializer.getStorage()
+                                                                         .retrieveMetadata(pid2));
+            compareValues(systemMetadata2, sysmetaFromHash);
+            sysmetaFromHash = TypeMarshaller.unmarshalTypeFromStream(SystemMetadata.class,
+                                                       MetacatInitializer.getStorage()
+                                                           .retrieveMetadata(pid3));
+            compareValues(systemMetadata3, sysmetaFromHash);
         } finally {
             try {
                 if (dest1.exists()) {
@@ -1006,8 +1105,34 @@ public class HashStoreUpgraderTest {
                 }
             } catch (Exception e) {
             }
+            try {
+                if (dest3.exists()) {
+                    dest3.delete();
+                }
+            } catch (Exception e) {
+            }
         }
 
+    }
+
+    private void compareValues(SystemMetadata mcSysmeta, SystemMetadata sysmeta)
+        throws Exception {
+        assertEquals(sysmeta.getIdentifier().getValue(), mcSysmeta.getIdentifier().getValue());
+        assertEquals(sysmeta.getFormatId().getValue(), mcSysmeta.getFormatId().getValue());
+        assertEquals(sysmeta.getSerialVersion().longValue(),
+                     mcSysmeta.getSerialVersion().longValue());
+        assertEquals(sysmeta.getSize().longValue(), mcSysmeta.getSize().longValue());
+        assertEquals(sysmeta.getChecksum().getValue(), mcSysmeta.getChecksum().getValue());
+        assertEquals(sysmeta.getChecksum().getAlgorithm(), mcSysmeta.getChecksum().getAlgorithm());
+        assertEquals(sysmeta.getSubmitter().getValue(), mcSysmeta.getSubmitter().getValue());
+        assertEquals(sysmeta.getRightsHolder().getValue(), mcSysmeta.getRightsHolder().getValue());
+        assertEquals(sysmeta.getDateUploaded().getTime(), mcSysmeta.getDateUploaded().getTime());
+        assertEquals(sysmeta.getDateSysMetadataModified().getTime(),
+                     mcSysmeta.getDateSysMetadataModified().getTime());
+        assertEquals(
+            sysmeta.getOriginMemberNode().getValue(), mcSysmeta.getOriginMemberNode().getValue());
+        assertEquals(sysmeta.getAuthoritativeMemberNode().getValue(),
+                     mcSysmeta.getAuthoritativeMemberNode().getValue());
     }
 
 }


### PR DESCRIPTION
Now the hashstore converter can handle the objects which don't have records in the `systemmetadata` and `identifier` tables. In theory, any objects in Metacat 3.0.0 should have the systemmetadata. However, the process to generate system metadata may not completely done during the previous upgrade. So the legacy Metacat instance may have some objects without system metadata. The feature can still convert them to hashstore and generate system metadata for them.