### PR TITLE
Add a property to disable the hastore conversion

### DIFF
--- a/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
+++ b/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
@@ -46,6 +46,19 @@ public class HashStoreConversionAdmin extends MetacatAdmin {
      * The method do the conversion job
      */
     public static void convert() {
+        try {
+            String disableConversion =
+                PropertyService.getProperty("storage.hashstore.disableConversion");
+            if (disableConversion != null && disableConversion.equalsIgnoreCase("true")) {
+                logMetacat.debug("Metacat disabled the hashstore conversion and will stop there.");
+                return;
+            }
+        } catch (PropertyNotFoundException e) {
+            // do nothing
+            logMetacat.debug(
+                "Metacat doesn't define the property of storage.hashstore.disableConversion. So it "
+                    + "will convert it.");
+        }
         logMetacat.debug("Start of the convert method...");
         String currentVersion = null;
         try {

--- a/test/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdminIT.java
+++ b/test/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdminIT.java
@@ -7,10 +7,13 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Properties;
 import java.util.Vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.never;
 
 /**
  * @author Tao
@@ -102,6 +105,19 @@ public class HashStoreConversionAdminIT {
         } finally {
             // Reset back the status
             HashStoreConversionAdmin.setStatus(currentVersion, currentStatus);
+        }
+    }
+
+    @Test
+    public void testDisableHashStoreConversion() throws Exception {
+        Properties withProperties = new Properties();
+        withProperties.setProperty("storage.hashstore.disableConversion", "true");
+        LeanTestUtils.initializeMockPropertyService(withProperties);
+        try (MockedStatic<HashStoreConversionAdmin> mocked =
+                 Mockito.mockStatic(HashStoreConversionAdmin.class, CALLS_REAL_METHODS)) {
+            HashStoreConversionAdmin.convert();
+            mocked.verify(() -> HashStoreConversionAdmin.generateFinalVersionsAndClassesMap(),
+                          never());
         }
     }
 }


### PR DESCRIPTION
Two parts of the merge:
1. Add a property to disable the hastore conversion. See this [ticket](https://github.com/NCEAS/metacat/issues/1987).
2. A leftover of a testing file which I forgot in the previous merge.