### PR TITLE
Metacat logs the information which contains the failed identifiers during the conversion 

### DIFF
--- a/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
+++ b/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
@@ -96,11 +96,13 @@ public class HashStoreConversionAdmin extends MetacatAdmin {
                     HashStoreUpgrader upgrader = (HashStoreUpgrader) utility;
                     String infoStr = upgrader.getInfo();
                     if (infoStr != null && !infoStr.isBlank()) {
-                        info.add("The conversion is complete! However, some of your data could "
-                                     + "not be converted, because it was in an inconsistent state "
-                                     + "before the process started. The following files contain "
-                                     + "the relevant identifiers and their associated errors.<br>");
+                        String preface = "The conversion is complete! However, some of your data could "
+                            + "not be converted, because it was in an inconsistent state "
+                            + "before the process started. The following files contain "
+                            + "the relevant identifiers and their associated errors.<br>";
+                        info.add(preface);
                         info.add(infoStr);
+                        logMetacat.warn(preface + " " + infoStr);
                     }
                 }
             }


### PR DESCRIPTION
The failed identifiers only were shown on the admin pages. However, the k8s operators usually don't see it. So we should log them into the log file.