### PR TITLE
Bug increase dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,10 @@
                   <groupId>org.slf4j</groupId>
                   <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>commons-io</groupId>
+                  <artifactId>commons-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
fix broken build on linux by excluding older commons-io from wicket-core dependency