### PR TITLE
Bugfix 2016 limit threads hashstore conv

### DIFF
--- a/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
+++ b/src/edu/ucsb/nceas/metacat/admin/HashStoreConversionAdmin.java
@@ -7,17 +7,13 @@ import edu.ucsb.nceas.metacat.database.DBConnectionPool;
 import edu.ucsb.nceas.metacat.properties.PropertyService;
 import edu.ucsb.nceas.metacat.shared.MetacatUtilException;
 import edu.ucsb.nceas.metacat.util.DatabaseUtil;
-import edu.ucsb.nceas.metacat.util.RequestUtil;
 import edu.ucsb.nceas.metacat.util.SystemUtil;
-import edu.ucsb.nceas.utilities.GeneralPropertyException;
 import edu.ucsb.nceas.utilities.PropertyNotFoundException;
 import org.apache.commons.collections4.map.ListOrderedMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -26,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
-import java.util.concurrent.Executors;
 
 /**
  * An admin class to convert the old style file store to a HashStore
@@ -184,7 +179,7 @@ public class HashStoreConversionAdmin extends MetacatAdmin {
             //No upgrade need, we determine the version from the map from the property file
             versionAndClassMap = versionAndClassMapInProperty;
         } else {
-            // There is a upgrade, we determine the version from the finalVersionAndClassMap
+            // There is an upgrade. We determine the version from the finalVersionAndClassMap
             versionAndClassMap = finalVersionAndClassMap;
         }
         // We combine the status for all status of the different versions
@@ -259,7 +254,7 @@ public class HashStoreConversionAdmin extends MetacatAdmin {
                     if (resultSet.next()) {
                         String statusStr =resultSet.getString(1);
                         if (statusStr != null && !statusStr.isBlank()) {
-                            logMetacat.debug("The status of storage_upgrade_status from the db is"
+                            logMetacat.debug("The status of storage_upgrade_status from the db is: "
                                                  + statusStr);
                             status = UpgradeStatus.getStatus(statusStr);
                         }

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -66,16 +66,27 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
     private File backupDir;
     private static int timeout = TIME_OUT_DAYS;
     private int maxSetSize = MAX_SET_SIZE;
-    private static int nThreads = 1;
+    protected static int nThreads;
 
     static {
-        // use a shared executor service with nThreads == one less than available processors or one
-        int availableProcessors = Runtime.getRuntime().availableProcessors();
-        nThreads = availableProcessors;
-        nThreads--;
-        nThreads = Math.max(1, nThreads);
+        // use a shared executor service with nThreads == one less than available processors (or one
+        // if there's only 1 processor), and limited by the max number of database connections.
+        int availDbConn;
+        try {
+            // Limit to DB conn pool size minus 5 for other processes
+            availDbConn =
+                Integer.parseInt(PropertyService.getProperty("database.maximumConnections")) - 5;
+        } catch (PropertyNotFoundException e) {
+            logMetacat.warn(
+                "unable to find database.maximumConnections property!"
+                + "Defaulting available DN connections to 195", e);
+            availDbConn = 195;
+        }
+        nThreads = Runtime.getRuntime().availableProcessors();
+        nThreads--;                                 // Leave 1 main thread for execution
+        nThreads = Math.max(1, nThreads);           // In case only 1 processor is available
+        nThreads = Math.min(availDbConn, nThreads); // Limit to available DB pool connections
         logMetacat.debug("The size of the thread pool to do the conversion job is " + nThreads);
-
     }
 
     /**
@@ -387,7 +398,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         } else {
             path = Paths.get(dataPath + localId);
         }
-        logMetacat.debug("The object path for " + pid.getValue() + " is " + path.toString());
+        logMetacat.debug("The object path for " + pid.getValue() + " is " + path);
         return path;
     }
 

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -87,6 +87,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         nThreads = Math.max(1, nThreads);           // In case only 1 processor is available
         nThreads = Math.min(availDbConn, nThreads); // Limit to available DB pool connections
         logMetacat.debug("The size of the thread pool to do the conversion job is " + nThreads);
+        logMetacat.debug("Available DB Connections were (tot - 5): " + availDbConn);
     }
 
     /**

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -76,6 +76,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             // Limit to DB conn pool size minus 5 for other processes
             availDbConn =
                 Integer.parseInt(PropertyService.getProperty("database.maximumConnections")) - 5;
+            availDbConn = Math.max(1, availDbConn); // In case "database.maximumConnections" < 6
         } catch (PropertyNotFoundException e) {
             logMetacat.warn(
                 "unable to find database.maximumConnections property!"


### PR DESCRIPTION
see #2016 

tested on my machine:
```
metacat 20241112-18:16:53: [DEBUG]: The size of the thread pool to do the conversion job is 9 [edu.ucsb.nceas.metacat.admin.upgrade.HashStoreUpgrader:<clinit>:89]
metacat 20241112-18:16:53: [DEBUG]: Available DB Connections were (tot - 5): 195 [edu.ucsb.nceas.metacat.admin.upgrade.HashStoreUpgrader:<clinit>:90]
```
(total 10 cores)