### PR TITLE
Feature 1347 hash store

### DIFF
--- a/src/edu/ucsb/nceas/metacat/IdentifierManager.java
+++ b/src/edu/ucsb/nceas/metacat/IdentifierManager.java
@@ -1402,7 +1402,8 @@ public class IdentifierManager {
               rev = rs.getInt(3);
               assert(db_guid.equals(guid));
           } else {
-              throw new McdbDocNotFoundException("Document not found:" + guid);
+              throw new McdbDocNotFoundException("Docid not found in the " + TYPE_IDENTIFIER
+                  + " table: " + guid);
           }
           stmt.close();
       } catch (SQLException e) {

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -299,7 +299,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                     + "network, please submit the file to knb-help@nceas.ucsb.edu so can we make "
                     + "changes on the CN part as well.";
                 try (BufferedWriter noChecksumInSysmetaWriter2 = new BufferedWriter(new FileWriter(
-                    noChecksumInSysmetaFile, append))) {
+                    nonMatchingChecksumFile, append))) {
                     writeToFile(message, noChecksumInSysmetaWriter2);
                 }
             }

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -212,6 +212,20 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                     SystemMetadata sysMeta =
                                         SystemMetadataManager.getInstance().get(pid);
                                     if (sysMeta == null) {
+                                        if (finalId.startsWith("autogen.")) {
+                                            // This is not a normal scenario. The
+                                            // autogen. is reserved docid for the Dataone objects
+                                            // . It always means there is no mapping between the
+                                            // autogen docid and the pid in the identifier table
+                                            throw new AdminException(
+                                                "Pid " + finalId + " is missing system "
+                                                    + "metadata. Since the pid starts with "
+                                                    + "autogen and looks like to be created by"
+                                                    + " DataONE api, it should have the "
+                                                    + "systemmetadata. Please look at the "
+                                                    + "systemmetadata and identifier table to "
+                                                    + "figure out the real pid.");
+                                        }
                                         // This is for the case that the object somehow hasn't been
                                         // transformed to the DataONE object: no system metadata
                                         // This method does not only create the system metadata,

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -213,6 +213,8 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                     if (sysMeta == null) {
                                         // This is for the case that the object somehow hasn't been
                                         // transformed to the DataONE object: no system metadata
+                                        // This method does not only create the system metadata,
+                                        // but also create the map in the identifier table.
                                         sysMeta =
                                             SystemMetadataFactory.createSystemMetadata(finalId);
                                         try {
@@ -224,7 +226,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                     }
                                     if (sysMeta != null) {
                                         SystemMetadata finalSysMeta = sysMeta;
-                                        Path path = resolve(finalSysMeta); // it may be null
+                                        Path path = resolve(finalSysMeta); // it may be null for cn
                                         if (finalSysMeta.getChecksum() != null) {
                                             String checksum = finalSysMeta.getChecksum().getValue();
                                             String algorithm =
@@ -420,6 +422,10 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         try {
             localId = IdentifierManager.getInstance().getLocalId(pid.getValue());
         } catch (McdbDocNotFoundException e) {
+            // If we can't find them in the identifier table, throw an exception for the mns.
+            // Note: those old metacat docid originally without system data already created the
+            // records in the systemmetadata and identifier tables during the call of the
+            // SystemMetadataFactory. createSystemMetadata method.
             if (isCN) {
                 return null;
             } else {
@@ -428,6 +434,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         }
         Path path;
         try {
+            // This method will look both the data and documents directories.
             File file = SystemMetadataFactory.getFileFromLegacyStore(localId);
             path = file.toPath();
         } catch (FileNotFoundException e) {

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -237,8 +237,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                                 "Trying to convert the storage to hashstore"
                                                     + " for " + id + " with checksum: " + checksum
                                                     + " algorithm: " + algorithm
-                                                    + " and file path(may be null): "
-                                                    + path.toString());
+                                                    + " and file path(may be null): " + path);
                                             Future<?> future = executor.submit(() -> {
                                                 convert(path, finalId, finalSysMeta, checksum,
                                                         algorithm, nonMatchingChecksumWriter,

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -5,6 +5,7 @@ import edu.ucsb.nceas.metacat.McdbDocNotFoundException;
 import edu.ucsb.nceas.metacat.admin.AdminException;
 import edu.ucsb.nceas.metacat.database.DBConnection;
 import edu.ucsb.nceas.metacat.database.DBConnectionPool;
+import edu.ucsb.nceas.metacat.dataone.D1NodeService;
 import edu.ucsb.nceas.metacat.dataone.SystemMetadataFactory;
 import edu.ucsb.nceas.metacat.properties.PropertyService;
 import edu.ucsb.nceas.metacat.shared.MetacatUtilException;
@@ -427,7 +428,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             // Note: those old metacat docid originally without system data already created the
             // records in the systemmetadata and identifier tables during the call of the
             // SystemMetadataFactory. createSystemMetadata method.
-            if (isCN) {
+            if (isCN && !D1NodeService.isScienceMetadata(sysMeta)) {
                 return null;
             } else {
                 throw e;

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -626,6 +626,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                 break;
             }
         }
+        logMetacat.error(info);
         writeToFile(info, nonMatchingChecksumWriter);
         return metadata;
     }

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -215,6 +215,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                         // transformed to the DataONE object: no system metadata
                                         // This method does not only create the system metadata,
                                         // but also create the map in the identifier table.
+                                        System.out.println("we need to create systemetadata");
                                         sysMeta =
                                             SystemMetadataFactory.createSystemMetadata(finalId);
                                         try {
@@ -593,8 +594,6 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         } finally {
             SystemMetadataManager.unLock(sysMeta.getIdentifier());
         }
-        SystemMetadataManager.getInstance().store(sysMeta, false,
-                                                  SystemMetadataManager.SysMetaVersion.UNCHECKED);
         logMetacat.debug("After saving to the db, the checksum from the new system metadata is "
                              + sysMeta.getChecksum().getValue());
         try (InputStream sysMetaInput = convertSystemMetadata(sysMeta)) {

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -68,7 +68,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
     private static int timeout = TIME_OUT_DAYS;
     private int maxSetSize = MAX_SET_SIZE;
     protected static int nThreads;
-    private static boolean isCN = false;
+    private boolean isCN = false;
 
     static {
         // use a shared executor service with nThreads == one less than available processors (or one
@@ -434,17 +434,9 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             }
         }
         Path path;
-        try {
-            // This method will look both the data and documents directories.
-            File file = SystemMetadataFactory.getFileFromLegacyStore(localId);
-            path = file.toPath();
-        } catch (FileNotFoundException e) {
-            if (isCN) {
-                return null;
-            } else {
-                throw e;
-            }
-        }
+        // This method will look both the data and documents directories.
+        File file = SystemMetadataFactory.getFileFromLegacyStore(localId);
+        path = file.toPath();
         logMetacat.debug("The object path for " + pid.getValue() + " is " + path);
         return path;
     }

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -280,6 +280,17 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                                    + "jobs was interrupted: " + e.getMessage());
                 }
             }
+            // Add a comment at the end of the non-matching checksum file
+            if (nonMatchingChecksumFile != null && nonMatchingChecksumFile.exists()
+                && nonMatchingChecksumFile.length() > 0) {
+                String message = "If this instance is a registered member node of the DataONE "
+                    + "network, please submit the file to knb-help@nceas.ucsb.edu so can we make "
+                    + "changes on the CN part as well.";
+                try (BufferedWriter noChecksumInSysmetaWriter2 = new BufferedWriter(new FileWriter(
+                    noChecksumInSysmetaFile, append))) {
+                    writeToFile(message, noChecksumInSysmetaWriter2);
+                }
+            }
             handleErrorFile(nonMatchingChecksumFile, infoBuffer);
             handleErrorFile(noSuchAlgorithmFile, infoBuffer);
             handleErrorFile(generalFile, infoBuffer);

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -215,7 +215,8 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                         // transformed to the DataONE object: no system metadata
                                         // This method does not only create the system metadata,
                                         // but also create the map in the identifier table.
-                                        System.out.println("we need to create systemetadata");
+                                        logMetacat.debug("We need to create the systemetadata for "
+                                                             + finalId);
                                         sysMeta =
                                             SystemMetadataFactory.createSystemMetadata(finalId);
                                         try {

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -32,6 +32,7 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -382,10 +383,11 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             return null;
         }
         Path path;
-        if (D1NodeService.isScienceMetadata(sysMeta)) {
-            path = Paths.get(documentPath + localId);
-        } else {
-            path = Paths.get(dataPath + localId);
+        try {
+            File file = SystemMetadataFactory.getFileFromLegacyStore(localId);
+            path = file.toPath();
+        } catch (FileNotFoundException e) {
+            return null;
         }
         logMetacat.debug("The object path for " + pid.getValue() + " is " + path.toString());
         return path;

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -585,6 +585,11 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             SystemMetadataManager.lock(sysMeta.getIdentifier());
             SystemMetadataManager.getInstance()
                 .store(sysMeta, false, SystemMetadataManager.SysMetaVersion.UNCHECKED);
+        } catch (Exception ee) {
+            logMetacat.error("Metacat couldn't save the system metadata with the correct checksum"
+                                 + " during the process to reconvert unmatched checksum object "
+                                 + finalId);
+            throw ee;
         } finally {
             SystemMetadataManager.unLock(sysMeta.getIdentifier());
         }

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -253,7 +253,7 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                                                 "Trying to convert the storage to hashstore"
                                                     + " for " + id + " with checksum: " + checksum
                                                     + " algorithm: " + algorithm
-                                                    + " and file path(may be null): " + path);
+                                                    + " and file path(may be null for cn): " + path);
                                             Future<?> future = executor.submit(() -> {
                                                 convert(path, finalId, finalSysMeta, checksum,
                                                         algorithm, nonMatchingChecksumWriter,
@@ -312,8 +312,8 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
             if (nonMatchingChecksumFile != null && nonMatchingChecksumFile.exists()
                 && nonMatchingChecksumFile.length() > 0) {
                 String message = "If this instance is a registered member node of the DataONE "
-                    + "network, please submit the file to knb-help@nceas.ucsb.edu so can we make "
-                    + "changes on the CN part as well.";
+                    + "network, please submit this file to knb-help@nceas.ucsb.edu so we can also "
+                    + "update the CN to reflect the above changes.";
                 try (BufferedWriter noChecksumInSysmetaWriter2 = new BufferedWriter(new FileWriter(
                     nonMatchingChecksumFile, append))) {
                     writeToFile(message, noChecksumInSysmetaWriter2);

--- a/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
+++ b/src/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgrader.java
@@ -519,6 +519,8 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
                     reConvertUnMatchedChecksumObject(path, finalId, sysMeta, e.getHexDigests(),
                                                      nonMatchingChecksumWriter);
             } catch (Exception ee) {
+                logMetacat.error("Cannot reconvert unMatchedChecksum object " + finalId + " since "
+                                     + e.getMessage());
                 writeToFile(finalId, e, generalWriter);
                 return;
             }
@@ -564,6 +566,8 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         String algorithm = sysMeta.getChecksum().getAlgorithm().toUpperCase();
         // Modify the System Metadata with the new checksum from hashstore
         String newChecksum = checksums.get(algorithm);
+        logMetacat.debug("the calculated checksum with algorithm " + algorithm + " from hashstore "
+                             + "is " + newChecksum);
         if (newChecksum == null || newChecksum.isBlank()) {
             throw new NoSuchAlgorithmException("HashStore doesn't have the checksum with the "
                                                    + "algorithm " + algorithm);
@@ -574,8 +578,12 @@ public class HashStoreUpgrader implements UpgradeUtilityInterface {
         sysMeta.setChecksum(checksum);
         //Save the new system metadata with correct the checksum to database and hashstore
         //false means no modification date change
+        logMetacat.debug("Before saving to the db, the checksum from the new system metadata is "
+                             + sysMeta.getChecksum().getValue());
         SystemMetadataManager.getInstance().store(sysMeta, false,
                                                   SystemMetadataManager.SysMetaVersion.UNCHECKED);
+        logMetacat.debug("After saving to the db, the checksum from the new system metadata is "
+                             + sysMeta.getChecksum().getValue());
         try (InputStream sysMetaInput = convertSystemMetadata(sysMeta)) {
             metadata = converter.convert(path, finalId, sysMetaInput, newChecksum, algorithm);
         }

--- a/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
+++ b/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
@@ -320,8 +320,13 @@ public class HashStoreUpgraderIT {
         SystemMetadata sysmeta2 =
             D1NodeServiceTest.createSystemMetadata(metadataPid, owner, object);
         sysmeta2.setFormatId(eml220_format_id);
-        path = upgrader.resolve(sysmeta2);
-        assertNull(path);
+        try {
+            path = upgrader.resolve(sysmeta2);
+        } catch (Exception e) {
+            assertTrue(e instanceof McdbDocNotFoundException);
+            assertTrue(e.getMessage().contains("identifier"));
+            assertTrue(e.getMessage().contains(metadataId));
+        }
 
         try (MockedStatic<IdentifierManager> ignore =
                  Mockito.mockStatic(IdentifierManager.class)) {

--- a/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
+++ b/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
@@ -632,6 +632,7 @@ public class HashStoreUpgraderIT {
             //assertTrue(hashstore.exists());
             // mock ResultSet
             ResultSet resultSetMock = Mockito.mock(ResultSet.class);
+            Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(false);
             Mockito.when(resultSetMock.getString(1)).thenReturn(dataId);
             // mock HashStoreUpgrader with the real methods
             HashStoreUpgrader upgrader = Mockito.mock(

--- a/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
+++ b/test/edu/ucsb/nceas/metacat/admin/upgrade/HashStoreUpgraderIT.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.withSettings;
  * @author Tao
  * The test class for HashStoreUpgrader
  */
-public class HashStoreUpgraderTest {
+public class HashStoreUpgraderIT {
     MockedStatic<PropertyService> closeableMock;
     String backupPath = "build/temp." + System.currentTimeMillis();
     String hashStorePath = "build/hashStore";

--- a/test/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactoryIT.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/SystemMetadataFactoryIT.java
@@ -135,22 +135,38 @@ public class SystemMetadataFactoryIT {
 
 
     /**
-     * Test the method of ReadFileFromLegacyStore
+     * Test the method of readInputStreamFromLegacyStore
      * @throws Exception
      */
     @Test
     public void testReadFileFromLegacyStore() throws Exception {
         Identifier identifier = new Identifier();
         identifier.setValue("eml-error-2.2.0.xml");
-        assertNotNull(SystemMetadataFactory.readFileFromLegacyStore(identifier));
+        assertNotNull(SystemMetadataFactory.readInputStreamFromLegacyStore(identifier));
         identifier.setValue("foo");
         try {
-            SystemMetadataFactory.readFileFromLegacyStore(identifier);
+            SystemMetadataFactory.readInputStreamFromLegacyStore(identifier);
             fail("Test shouldn't get here since the foo file doesn't exist");
         } catch (Exception e) {
             assertTrue(e instanceof FileNotFoundException);
         }
         identifier.setValue("onlineDataFile1");
-        assertNotNull(SystemMetadataFactory.readFileFromLegacyStore(identifier));
+        assertNotNull(SystemMetadataFactory.readInputStreamFromLegacyStore(identifier));
+    }
+
+    /**
+     * Test the method of getFileFromLegacyStore
+     * @throws Exception
+     */
+    @Test
+    public void testGetFileFromLegacyStore() throws Exception {
+        assertTrue(SystemMetadataFactory.getFileFromLegacyStore("eml-error-2.2.0.xml").exists());
+        try {
+            SystemMetadataFactory.getFileFromLegacyStore("foo1");
+            fail("Test shouldn't get here since the foo file doesn't exist");
+        } catch (Exception e) {
+            assertTrue(e instanceof FileNotFoundException);
+        }
+        assertTrue(SystemMetadataFactory.getFileFromLegacyStore("onlineDataFile1").exists());
     }
 }


### PR DESCRIPTION
This PR has those changes:
1. If the checksum of an object doesn't match the hashstore's calculation during the conversion, Metacat still converts it to the hashstore and write a record to a file.
2. If a DataONE object is missing the record in the identifier table, Metacat will stop conversion and leave the error in the file.
3. Metacat will look an object in both legacy data and document directories.
4. Fixed a bug which may cause the null exception