### PR TITLE
ingress: add ability to include arbitrary rules yaml

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -62,22 +62,9 @@ spec:
   {{- end }}
   {{- end }}
   rules:
-    {{- if .Values.ingress.hosts }}
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}-hl
-                port:
-                  number: 8080
-          {{- end }}
-    {{- end }}
-    {{- else }}
+  {{- if and (.Values.ingress.rules) (ne (len .Values.ingress.rules) 0) }}
+    {{- .Values.ingress.rules | toYaml | nindent 4 }}
+  {{- else }}
     - host: {{ $serverName }}
       http:
         paths:
@@ -98,5 +85,5 @@ spec:
                 port:
                   number: 80
           {{- end }}
-    {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -778,6 +778,31 @@ ingress:
   ##
   tls: []
 
+  ## @param ingress.rules The Ingress rules can be defined here or left blank to be auto-populated
+  ## based on the metacat.server.name value. If defining rules here, they will be copied verbatim
+  ## to the ingress definition. For schema guidance, see:
+  ## https://kubernetes.io/docs/concepts/services-networking/ingress/
+  ## Example:
+  ##    - host: goa.nceas.ucsb.edu
+  ##      http:
+  ##        paths:
+  ##          - backend:
+  ##              service:
+  ##                name: metacatgoa-hl
+  ##                port:
+  ##                  number: 8080
+  ##            path: /goa
+  ##            pathType: Prefix
+  ##          - backend:
+  ##              service:
+  ##                name: metacatgoa-metacatui
+  ##                port:
+  ##                  number: 80
+  ##            path: /
+  ##            pathType: Prefix
+  ##
+  rules: []
+
   ## @param ingress.d1CaCertSecretName Name of Secret containing DataONE CA certificate chain
   ## For DataONE Replication -- mutual authentication with x509 client-side certs.
   ## Also see `metacat.dataone.certificate.fromHttpHeader.enabled`


### PR DESCRIPTION
Add the ability to include arbitrary yaml subtree under spec: rules: in ingress.yaml