### PR TITLE
add fsGroupChangePolicy: OnRootMismatch

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -155,7 +155,7 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 ### Global Properties Shared Across Sub-Charts Within This Deployment
 
 | Name                                 | Description                                                     | Value                             |
-| ------------------------------------ | --------------------------------------------------------------- | --------------------------------- |
+|--------------------------------------|-----------------------------------------------------------------|-----------------------------------|
 | `global.metacatExternalBaseUrl`      | Metacat base url accessible from outside cluster.               | `https://localhost/`              |
 | `global.d1ClientCnUrl`               | The url of the CN; used to populate metacat's 'D1Client.CN_URL' | `https://cn.dataone.org/cn`       |
 | `global.passwordsSecret`             | The name of the Secret containing application passwords         | `${RELEASE_NAME}-metacat-secrets` |
@@ -171,7 +171,7 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 ### Metacat Application-Specific Properties
 
 | Name                              | Description                                                     | Value               |
-| --------------------------------- | --------------------------------------------------------------- | ------------------- |
+|-----------------------------------|-----------------------------------------------------------------|---------------------|
 | `metacat.application.context`     | see global.metacatAppContext                                    | `metacat`           |
 | `metacat.auth.administrators`     | A semicolon-separated list of admin ORCID iDs                   | `""`                |
 | `metacat.database.connectionURI`  | postgres database URI, or lave blank to use sub-chart           | `""`                |
@@ -186,33 +186,33 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 
 ### OPTIONAL DataONE Member Node (MN) Parameters
 
-| Name                                                          | Description                                                       | Value                                                    |
-| ------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
-| `metacat.cn.server.publiccert.filename`                       | optional cert(s) used to validate jwt auth tokens,                | `/var/metacat/pubcerts/DataONEProdIntCA.pem`             |
-| `metacat.dataone.certificate.fromHttpHeader.enabled`          | Enable mutual auth with client certs                              | `false`                                                  |
-| `metacat.dataone.autoRegisterMemberNode`                      | Automatically push MN updates to CN? (yyyy-MM-dd)                 | `2023-02-28`                                             |
-| `metacat.dataone.nodeId`                                      | The unique ID of your DataONE MN - must match client cert subject | `urn:node:CHANGE_ME_TO_YOUR_VALUE!`                      |
-| `metacat.dataone.subject`                                     | The "subject" string from your DataONE MN client certificate      | `CN=urn:node:CHANGE_ME_TO_YOUR_VALUE!,DC=dataone,DC=org` |
-| `metacat.dataone.nodeName`                                    | short name for the node that can be used in user interfaces       | `My Metacat Node`                                        |
-| `metacat.dataone.nodeDescription`                             | What is the node's intended scope and purpose?                    | `Describe your Member Node briefly.`                     |
-| `metacat.dataone.contactSubject`                              | registered contact for this MN                                    | `http://orcid.org/0000-0002-8888-999X`                   |
-| `metacat.dataone.nodeSynchronize`                             | Enable Synchronization of Metadata to DataONE                     | `false`                                                  |
-| `metacat.dataone.nodeSynchronization.schedule.year`           | sync schedule year                                                | `*`                                                      |
-| `metacat.dataone.nodeSynchronization.schedule.mon`            | sync schedule month                                               | `*`                                                      |
-| `metacat.dataone.nodeSynchronization.schedule.mday`           | sync schedule day of month                                        | `*`                                                      |
-| `metacat.dataone.nodeSynchronization.schedule.wday`           | sync schedule day of week                                         | `?`                                                      |
-| `metacat.dataone.nodeSynchronization.schedule.hour`           | sync schedule hour                                                | `*`                                                      |
-| `metacat.dataone.nodeSynchronization.schedule.min`            | sync schedule minute                                              | `0/3`                                                    |
-| `metacat.dataone.nodeSynchronization.schedule.sec`            | sync schedule second                                              | `10`                                                     |
-| `metacat.dataone.nodeReplicate`                               | Accept and Store Replicas?                                        | `false`                                                  |
-| `metacat.dataone.replicationpolicy.default.numreplicas`       | # copies to store on other nodes                                  | `0`                                                      |
-| `metacat.dataone.replicationpolicy.default.preferredNodeList` | Preferred replication nodes                                       | `nil`                                                    |
-| `metacat.dataone.replicationpolicy.default.blockedNodeList`   | Nodes blocked from replication                                    | `nil`                                                    |
+| Name                                                          | Description                                                       | Value                                        |
+|---------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------|
+| `metacat.cn.server.publiccert.filename`                       | optional cert(s) used to validate jwt auth tokens,                | `/var/metacat/pubcerts/DataONEProdIntCA.pem` |
+| `metacat.dataone.certificate.fromHttpHeader.enabled`          | Enable mutual auth with client certs                              | `false`                                      |
+| `metacat.dataone.autoRegisterMemberNode`                      | Automatically push MN updates to CN? (yyyy-MM-dd)                 | `2023-02-28`                                 |
+| `metacat.dataone.nodeId`                                      | The unique ID of your DataONE MN - must match client cert subject | `urn:node:METACAT_TEST`                      |
+| `metacat.dataone.subject`                                     | The "subject" string from your DataONE MN client certificate      | `CN=urn:node:METACAT1,DC=dataone,DC=org`     |
+| `metacat.dataone.nodeName`                                    | short name for the node that can be used in user interfaces       | `My Metacat Node`                            |
+| `metacat.dataone.nodeDescription`                             | What is the node's intended scope and purpose?                    | `Describe your Member Node briefly.`         |
+| `metacat.dataone.contactSubject`                              | registered contact for this MN                                    | `http://orcid.org/0000-0002-8888-999X`       |
+| `metacat.dataone.nodeSynchronize`                             | Enable Synchronization of Metadata to DataONE                     | `false`                                      |
+| `metacat.dataone.nodeSynchronization.schedule.year`           | sync schedule year                                                | `*`                                          |
+| `metacat.dataone.nodeSynchronization.schedule.mon`            | sync schedule month                                               | `*`                                          |
+| `metacat.dataone.nodeSynchronization.schedule.mday`           | sync schedule day of month                                        | `*`                                          |
+| `metacat.dataone.nodeSynchronization.schedule.wday`           | sync schedule day of week                                         | `?`                                          |
+| `metacat.dataone.nodeSynchronization.schedule.hour`           | sync schedule hour                                                | `*`                                          |
+| `metacat.dataone.nodeSynchronization.schedule.min`            | sync schedule minute                                              | `0/3`                                        |
+| `metacat.dataone.nodeSynchronization.schedule.sec`            | sync schedule second                                              | `10`                                         |
+| `metacat.dataone.nodeReplicate`                               | Accept and Store Replicas?                                        | `false`                                      |
+| `metacat.dataone.replicationpolicy.default.numreplicas`       | # copies to store on other nodes                                  | `0`                                          |
+| `metacat.dataone.replicationpolicy.default.preferredNodeList` | Preferred replication nodes                                       | `""`                                         |
+| `metacat.dataone.replicationpolicy.default.blockedNodeList`   | Nodes blocked from replication                                    | `""`                                         |
 
 ### OPTIONAL (but Recommended) Site Map Parameters
 
 | Name                            | Description                                                     | Value      |
-| ------------------------------- | --------------------------------------------------------------- | ---------- |
+|---------------------------------|-----------------------------------------------------------------|------------|
 | `metacat.sitemap.enabled`       | Enable sitemaps to tell search engines which URLs are available | `false`    |
 | `metacat.sitemap.interval`      | Interval (in milliseconds) between rebuilding the sitemap       | `86400000` |
 | `metacat.sitemap.location.base` | The first part of the URLs listed in sitemap_index.xml          | `/`        |
@@ -221,38 +221,39 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 ### robots.txt file (search engine indexing)
 
 | Name               | Description                                                          | Value |
-| ------------------ | -------------------------------------------------------------------- | ----- |
+|--------------------|----------------------------------------------------------------------|-------|
 | `robots.userAgent` | "User-agent:" defined in robots.txt file. Defaults to "*" if not set | `""`  |
 | `robots.disallow`  | the "Disallow:" value defined in robots.txt file.                    | `""`  |
 
 ### Metacat Image, Container & Pod Parameters
 
-| Name                                    | Description                                                                  | Value                   |
-| --------------------------------------- | ---------------------------------------------------------------------------- | ----------------------- |
-| `image.repository`                      | Metacat image repository                                                     | `ghcr.io/nceas/metacat` |
-| `image.pullPolicy`                      | Metacat image pull policy                                                    | `IfNotPresent`          |
-| `image.tag`                             | Overrides the image tag. Will default to the chart appVersion if set to ""   | `""`                    |
-| `image.debug`                           | Specify if container debugging should be enabled (sets log level to "DEBUG") | `false`                 |
-| `imagePullSecrets`                      | Optional list of references to secrets in the same namespace                 | `[]`                    |
-| `container.ports`                       | Optional list of additional container ports to expose within the cluster     | `[]`                    |
-| `serviceAccount.create`                 | Should a service account be created to run Metacat?                          | `false`                 |
-| `serviceAccount.annotations`            | Annotations to add to the service account                                    | `{}`                    |
-| `serviceAccount.name`                   | The name to use for the service account.                                     | `""`                    |
-| `podAnnotations`                        | Map of annotations to add to the pods                                        | `{}`                    |
-| `podSecurityContext.enabled`            | Enable security context                                                      | `true`                  |
-| `podSecurityContext.runAsUser`          | numerical User ID for the pod                                                | `59997`                 |
-| `podSecurityContext.runAsGroup`         | numerical Group ID for the pod                                               | `59997`                 |
-| `podSecurityContext.fsGroup`            | numerical Group ID used to access mounted volumes                            | `59997`                 |
-| `podSecurityContext.supplementalGroups` | additional GIDs used to access vol. mounts                                   | `[]`                    |
-| `podSecurityContext.runAsNonRoot`       | ensure all containers run as a non-root user.                                | `true`                  |
-| `securityContext`                       | holds container-level security attributes that override those at pod level   | `{}`                    |
-| `resources`                             | Resource limits for the deployment                                           | `{}`                    |
-| `tolerations`                           | Tolerations for pod assignment                                               | `[]`                    |
+| Name                                     | Description                                                                  | Value                   |
+|------------------------------------------|------------------------------------------------------------------------------|-------------------------|
+| `image.repository`                       | Metacat image repository                                                     | `ghcr.io/nceas/metacat` |
+| `image.pullPolicy`                       | Metacat image pull policy                                                    | `IfNotPresent`          |
+| `image.tag`                              | Overrides the image tag. Will default to the chart appVersion if set to ""   | `""`                    |
+| `image.debug`                            | Specify if container debugging should be enabled (sets log level to "DEBUG") | `false`                 |
+| `imagePullSecrets`                       | Optional list of references to secrets in the same namespace                 | `[]`                    |
+| `container.ports`                        | Optional list of additional container ports to expose within the cluster     | `[]`                    |
+| `serviceAccount.create`                  | Should a service account be created to run Metacat?                          | `false`                 |
+| `serviceAccount.annotations`             | Annotations to add to the service account                                    | `{}`                    |
+| `serviceAccount.name`                    | The name to use for the service account.                                     | `""`                    |
+| `podAnnotations`                         | Map of annotations to add to the pods                                        | `{}`                    |
+| `podSecurityContext.enabled`             | Enable security context                                                      | `true`                  |
+| `podSecurityContext.runAsUser`           | numerical User ID for the pod                                                | `59997`                 |
+| `podSecurityContext.runAsGroup`          | numerical Group ID for the pod                                               | `59997`                 |
+| `podSecurityContext.fsGroup`             | numerical Group ID used to access mounted volumes                            | `59997`                 |
+| `podSecurityContext.supplementalGroups`  | additional GIDs used to access vol. mounts                                   | `[]`                    |
+| `podSecurityContext.runAsNonRoot`        | ensure all containers run as a non-root user.                                | `true`                  |
+| `podSecurityContext.fsGroupChangePolicy` | control how Kubernetes manages ownership & perms...                          | `OnRootMismatch`        |
+| `securityContext`                        | holds container-level security attributes that override those at pod level   | `{}`                    |
+| `resources`                              | Resource limits for the deployment                                           | `{}`                    |
+| `tolerations`                            | Tolerations for pod assignment                                               | `[]`                    |
 
 ### Metacat Persistence
 
 | Name                        | Description                                                          | Value               |
-| --------------------------- | -------------------------------------------------------------------- | ------------------- |
+|-----------------------------|----------------------------------------------------------------------|---------------------|
 | `persistence.enabled`       | Enable metacat data persistence using Persistent Volume Claims       | `true`              |
 | `persistence.storageClass`  | Storage class of backing PV                                          | `local-path`        |
 | `persistence.existingClaim` | Name of an existing Persistent Volume Claim to re-use                | `""`                |
@@ -263,45 +264,47 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 
 ### Networking & Monitoring
 
-| Name                                                                      | Description                                                 | Value           |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------- |
-| `ingress.enabled`                                                         | Enable or disable the ingress                               | `true`          |
-| `ingress.className`                                                       | ClassName of the ingress provider in your cluster           | `nginx`         |
-| `ingress.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size` | - see docs:                                                 | see values.yaml |
-| `ingress.annotations.nginx.ingress.kubernetes.io/client_max_body_size`    | - see docs:                                                 | see values.yaml |
-| `ingress.defaultBackend.enabled`                                          | enable the optional defaultBackend                          | `false`         |
-| `ingress.defaultBackend.enabled`                                          | enable the optional defaultBackend                          | `false`         |
-| `ingress.rewriteRules`                                                    | rewrite rules for the nginx ingress                         | `[]`            |
-| `ingress.tls`                                                             | The TLS configuration                                       | `[]`            |
-| `ingress.d1CaCertSecretName`                                              | Name of Secret containing DataONE CA certificate chain      | `d1-ca-chain`   |
-| `service.enabled`                                                         | Enable another optional service in addition to headless svc | `false`         |
-| `service.type`                                                            | Kubernetes Service type. Defaults to ClusterIP if not set   | `LoadBalancer`  |
-| `service.clusterIP`                                                       | IP address of the service. Auto-generated if not set        | `""`            |
-| `service.ports`                                                           | The port(s) to be exposed                                   | `[]`            |
-| `livenessProbe.enabled`                                                   | Enable livenessProbe for Metacat container                  | `true`          |
-| `livenessProbe.httpGet.path`                                              | The url path to probe.                                      | `/metacat/`     |
-| `livenessProbe.httpGet.port`                                              | The named containerPort to probe                            | `metacat-web`   |
-| `livenessProbe.initialDelaySeconds`                                       | Initial delay seconds for livenessProbe                     | `45`            |
-| `livenessProbe.periodSeconds`                                             | Period seconds for livenessProbe                            | `15`            |
-| `livenessProbe.timeoutSeconds`                                            | Timeout seconds for livenessProbe                           | `10`            |
-| `readinessProbe.enabled`                                                  | Enable readinessProbe for Metacat container                 | `true`          |
-| `readinessProbe.httpGet.path`                                             | The url path to probe.                                      | `/metacat/admin`|
-| `readinessProbe.httpGet.port`                                             | The named containerPort to probe                            | `metacat-web`   |
-| `readinessProbe.initialDelaySeconds`                                      | Initial delay seconds for readinessProbe                    | `45`            |
-| `readinessProbe.periodSeconds`                                            | Period seconds for readinessProbe                           | `5`             |
-| `readinessProbe.timeoutSeconds`                                           | Timeout seconds for readinessProbe                          | `5`             |
+| Name                                                                      | Description                                                              | Value            |
+|---------------------------------------------------------------------------|--------------------------------------------------------------------------|------------------|
+| `ingress.enabled`                                                         | Enable or disable the ingress                                            | `true`           |
+| `ingress.className`                                                       | ClassName of the ingress provider in your cluster                        | `nginx`          |
+| `ingress.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size` | See docs:                                                                | `"1m"`           |
+| `ingress.annotations.nginx.ingress.kubernetes.io/client_max_body_size`    | See docs:                                                                | `"0"`            |
+| `ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size`         | See docs:                                                                | `"0"`            |
+| `ingress.defaultBackend.enabled`                                          | enable the optional defaultBackend                                       | `false`          |
+| `ingress.defaultBackend.enabled`                                          | enable the optional defaultBackend                                       | `false`          |
+| `ingress.rewriteRules`                                                    | formatted text rewrite rules for the nginx ingress                       | `""`             |
+| `ingress.tls`                                                             | The TLS configuration                                                    | `[]`             |
+| `ingress.rules`                                                           | The Ingress rules can be defined here or left blank to be auto-populated | `[]`             |
+| `ingress.d1CaCertSecretName`                                              | Name of Secret containing DataONE CA certificate chain                   | `d1-ca-chain`    |
+| `service.enabled`                                                         | Enable another optional service in addition to headless svc              | `false`          |
+| `service.type`                                                            | Kubernetes Service type. Defaults to ClusterIP if not set                | `LoadBalancer`   |
+| `service.clusterIP`                                                       | IP address of the service. Auto-generated if not set                     | `""`             |
+| `service.ports`                                                           | The port(s) to be exposed                                                | `[]`             |
+| `livenessProbe.enabled`                                                   | Enable livenessProbe for Metacat container                               | `true`           |
+| `livenessProbe.httpGet.path`                                              | The url path to probe.                                                   | `/metacat/`      |
+| `livenessProbe.httpGet.port`                                              | The named containerPort to probe                                         | `metacat-web`    |
+| `livenessProbe.initialDelaySeconds`                                       | Initial delay seconds for livenessProbe                                  | `45`             |
+| `livenessProbe.periodSeconds`                                             | Period seconds for livenessProbe                                         | `15`             |
+| `livenessProbe.timeoutSeconds`                                            | Timeout seconds for livenessProbe                                        | `10`             |
+| `readinessProbe.enabled`                                                  | Enable readinessProbe for Metacat container                              | `true`           |
+| `readinessProbe.httpGet.path`                                             | The url path to probe.                                                   | `/metacat/admin` |
+| `readinessProbe.httpGet.port`                                             | The named containerPort to probe                                         | `metacat-web`    |
+| `readinessProbe.initialDelaySeconds`                                      | Initial delay seconds for readinessProbe                                 | `45`             |
+| `readinessProbe.periodSeconds`                                            | Period seconds for readinessProbe                                        | `5`              |
+| `readinessProbe.timeoutSeconds`                                           | Timeout seconds for readinessProbe                                       | `5`              |
 
 ### Postgresql Sub-Chart
 
 | Name                                                    | Description                                         | Value                             |
-| ------------------------------------------------------- | --------------------------------------------------- | ----------------------------------|
+|---------------------------------------------------------|-----------------------------------------------------|-----------------------------------|
 | `postgresql.enabled`                                    | enable the postgresql sub-chart                     | `true`                            |
 | `postgresql.auth.username`                              | Username for accessing the database used by metacat | `metacat`                         |
 | `postgresql.auth.database`                              | The name of the database used by metacat.           | `metacat`                         |
 | `postgresql.auth.existingSecret`                        | Secrets location for postgres password              | `${RELEASE_NAME}-metacat-secrets` |
 | `postgresql.auth.secretKeys.userPasswordKey`            | Identifies metacat db's account password            | `POSTGRES_PASSWORD`               |
 | `postgresql.auth.secretKeys.adminPasswordKey`           | Dummy value - not used (see notes):                 | `POSTGRES_PASSWORD`               |
-| `postgresql.primary.pgHbaConfiguration`                 | PostgreSQL Primary client authentication            | see values.yaml                   |
+| `postgresql.primary.pgHbaConfiguration`                 | PostgreSQL Primary client authentication            | See Values.yaml                   |
 | `postgresql.primary.containerSecurityContext.enabled`   | enable containerSecurityContext                     | `true`                            |
 | `postgresql.primary.containerSecurityContext.runAsUser` | uid for container to run as                         | `59996`                           |
 | `postgresql.primary.podSecurityContext.runAsNonRoot`    | pod defaults to run as non-root?                    | `true`                            |
@@ -314,14 +317,14 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 ### Tomcat Configuration
 
 | Name                    | Description                                              | Value |
-| ----------------------- | -------------------------------------------------------- | ----- |
+|-------------------------|----------------------------------------------------------|-------|
 | `tomcat.heapMemory.min` | minimum memory heap size for Tomcat (-Xms JVM parameter) | `""`  |
 | `tomcat.heapMemory.max` | maximum memory heap size for Tomcat (-Xmx JVM parameter) | `""`  |
 
 ### dataone-indexer Sub-Chart
 
 | Name                                                         | Description                                       | Value                                 |
-| ------------------------------------------------------------ | ------------------------------------------------- | ------------------------------------- |
+|--------------------------------------------------------------|---------------------------------------------------|---------------------------------------|
 | `dataone-indexer.podSecurityContext.fsGroup`                 | gid used to access mounted volumes                | `59997`                               |
 | `dataone-indexer.podSecurityContext.supplementalGroups`      | additional vol access gids                        | `[]`                                  |
 | `dataone-indexer.persistence.subPath`                        | The subdirectory of the volume to mount           | `""`                                  |

--- a/helm/README.md
+++ b/helm/README.md
@@ -296,23 +296,24 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 
 ### Postgresql Sub-Chart
 
-| Name                                                    | Description                                         | Value                             |
-|---------------------------------------------------------|-----------------------------------------------------|-----------------------------------|
-| `postgresql.enabled`                                    | enable the postgresql sub-chart                     | `true`                            |
-| `postgresql.auth.username`                              | Username for accessing the database used by metacat | `metacat`                         |
-| `postgresql.auth.database`                              | The name of the database used by metacat.           | `metacat`                         |
-| `postgresql.auth.existingSecret`                        | Secrets location for postgres password              | `${RELEASE_NAME}-metacat-secrets` |
-| `postgresql.auth.secretKeys.userPasswordKey`            | Identifies metacat db's account password            | `POSTGRES_PASSWORD`               |
-| `postgresql.auth.secretKeys.adminPasswordKey`           | Dummy value - not used (see notes):                 | `POSTGRES_PASSWORD`               |
-| `postgresql.primary.pgHbaConfiguration`                 | PostgreSQL Primary client authentication            | See Values.yaml                   |
-| `postgresql.primary.containerSecurityContext.enabled`   | enable containerSecurityContext                     | `true`                            |
-| `postgresql.primary.containerSecurityContext.runAsUser` | uid for container to run as                         | `59996`                           |
-| `postgresql.primary.podSecurityContext.runAsNonRoot`    | pod defaults to run as non-root?                    | `true`                            |
-| `postgresql.primary.extendedConfiguration`              | Extended configuration, appended to defaults        | `max_connections = 250`           |
-| `postgresql.primary.persistence.enabled`                | Enable data persistence using PVC                   | `true`                            |
-| `postgresql.primary.persistence.existingClaim`          | Existing PVC to re-use                              | `""`                              |
-| `postgresql.primary.persistence.storageClass`           | Storage class of backing PV                         | `""`                              |
-| `postgresql.primary.persistence.size`                   | PVC Storage Request for postgres volume             | `1Gi`                             |
+| Name                                                        | Description                                         | Value                             |
+|-------------------------------------------------------------|-----------------------------------------------------|-----------------------------------|
+| `postgresql.enabled`                                        | enable the postgresql sub-chart                     | `true`                            |
+| `postgresql.auth.username`                                  | Username for accessing the database used by metacat | `metacat`                         |
+| `postgresql.auth.database`                                  | The name of the database used by metacat.           | `metacat`                         |
+| `postgresql.auth.existingSecret`                            | Secrets location for postgres password              | `${RELEASE_NAME}-metacat-secrets` |
+| `postgresql.auth.secretKeys.userPasswordKey`                | Identifies metacat db's account password            | `POSTGRES_PASSWORD`               |
+| `postgresql.auth.secretKeys.adminPasswordKey`               | Dummy value - not used (see notes):                 | `POSTGRES_PASSWORD`               |
+| `postgresql.primary.pgHbaConfiguration`                     | PostgreSQL Primary client authentication            | See Values.yaml                   |
+| `postgresql.primary.containerSecurityContext.enabled`       | enable containerSecurityContext                     | `true`                            |
+| `postgresql.primary.containerSecurityContext.runAsUser`     | uid for container to run as                         | `59996`                           |
+| `postgresql.primary.podSecurityContext.runAsNonRoot`        | pod defaults to run as non-root?                    | `true`                            |
+| `postgresql.primary.extendedConfiguration`                  | Extended configuration, appended to defaults        | `max_connections = 250`           |
+| `postgresql.primary.persistence.enabled`                    | Enable data persistence using PVC                   | `true`                            |
+| `postgresql.primary.persistence.existingClaim`              | Existing PVC to re-use                              | `""`                              |
+| `postgresql.primary.persistence.storageClass`               | Storage class of backing PV                         | `""`                              |
+| `postgresql.primary.persistence.size`                       | PVC Storage Request for postgres volume             | `1Gi`                             |
+| `postgresql.primary.podSecurityContext.fsGroupChangePolicy` | ownership & perms mgmt                              | `OnRootMismatch`                  |
 
 ### Tomcat Configuration
 
@@ -328,6 +329,7 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 | `dataone-indexer.podSecurityContext.fsGroup`                 | gid used to access mounted volumes                | `59997`                               |
 | `dataone-indexer.podSecurityContext.supplementalGroups`      | additional vol access gids                        | `[]`                                  |
 | `dataone-indexer.persistence.subPath`                        | The subdirectory of the volume to mount           | `""`                                  |
+| `dataone-indexer.podSecurityContext.fsGroupChangePolicy`     | ownership & perms mgmt                            | `OnRootMismatch`                      |
 | `dataone-indexer.rabbitmq.extraConfiguration`                | extra config, to be appended to rmq config        | `consumer_timeout = 144000000`        |
 | `dataone-indexer.rabbitmq.auth.username`                     | set the username that rabbitmq will use           | `metacat-rmq-guest`                   |
 | `dataone-indexer.rabbitmq.auth.existingPasswordSecret`       | location of rabbitmq password                     | `${RELEASE_NAME}-metacat-secrets`     |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -588,7 +588,7 @@ podSecurityContext:
   fsGroup: &mcFsGroup 59997
   supplementalGroups: &mcSupplementalGroups [ 997, 1000 ]
   runAsNonRoot: true
-  fsGroupChangePolicy: OnRootMismatch
+  fsGroupChangePolicy: &defaultFsGroupChangePolicy OnRootMismatch
 
 ## @param securityContext holds container-level security attributes that override those at pod level
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -953,6 +953,11 @@ postgresql:
       ## @param postgresql.primary.podSecurityContext.runAsNonRoot pod defaults to run as non-root?
       ##
       runAsNonRoot: true
+      ## @param postgresql.primary.podSecurityContext.fsGroupChangePolicy ownership & perms mgmt
+      ##                        IMPORTANT: use "OnRootMismatch" for large volumes! Using "Always"
+      ##                        means K8s will always chown the volume to the fsGroup, even if the
+      ##                        volume is already owned by the fsGroup, which is VERY slow!
+      fsGroupChangePolicy: *defaultFsGroupChangePolicy
 
     ## override the default pg_hba.conf with our own, to allow password auth, since this is the
     ## only method metacat currently supports (as of June 2023)
@@ -1015,9 +1020,14 @@ dataone-indexer:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param dataone-indexer.podSecurityContext.fsGroup gid used to access mounted volumes
   ## @param dataone-indexer.podSecurityContext.supplementalGroups [array] additional vol access gids
+  ## @param dataone-indexer.podSecurityContext.fsGroupChangePolicy ownership & perms mgmt
+  ##                        IMPORTANT: use "OnRootMismatch" for large volumes! Using "Always"
+  ##                        means K8s will always chown the volume to the fsGroup, even if the
+  ##                        volume is already owned by the fsGroup, which is VERY slow!
   podSecurityContext:
     fsGroup: *mcFsGroup
     supplementalGroups: *mcSupplementalGroups
+    fsGroupChangePolicy: *defaultFsGroupChangePolicy
 
   persistence:
     ## @param dataone-indexer.persistence.subPath The subdirectory of the volume to mount

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -576,6 +576,10 @@ podAnnotations: {}
 ## @param podSecurityContext.supplementalGroups [array] additional GIDs used to access vol. mounts
 ## @param podSecurityContext.runAsNonRoot ensure all containers run as a non-root user.
 ##                                 Note users must be defined by numerical user id for this to work
+## @param podSecurityContext.fsGroupChangePolicy control how Kubernetes manages ownership & perms...
+##                                IMPORTANT: use "OnRootMismatch" for large volumes! Using "Always"
+##                                means K8s will always chown the volume to the fsGroup, even if the
+##                                volume is already owned by the fsGroup, which is VERY slow!
 ## NOTE: If mounting an existing volume containing data, make sure the fsGroup is set to match
 ## the group that owns the existing data on that filesystem!
 ##
@@ -586,6 +590,7 @@ podSecurityContext:
   fsGroup: &mcFsGroup 59997
   supplementalGroups: &mcSupplementalGroups [ 997, 1000 ]
   runAsNonRoot: true
+  fsGroupChangePolicy: OnRootMismatch
 
 ## @param securityContext holds container-level security attributes that override those at pod level
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -282,9 +282,7 @@ metacat:
   ## 3. You DO NOT need to configure the Member Node client cert location. Instead, simply add it as
   ##    a secret: https://github.com/NCEAS/metacat/tree/develop/helm#install-the-client-certificate
   ##
-  ## (Default value shown - no need to uncomment unless changing from this)
-  ##
-#  dataone.certificate.fromHttpHeader.enabled: false
+  dataone.certificate.fromHttpHeader.enabled: false
 
   ## @param metacat.dataone.autoRegisterMemberNode Automatically push MN updates to CN? (yyyy-MM-dd)
   ## USE WITH CARE!
@@ -294,7 +292,7 @@ metacat:
   ## metacat startup), IN UTC (Coordinated Universal Time) ZONE.
   ## Format: yyyy-MM-dd; e.g. 2023-02-28
   ##
-#  dataone.autoRegisterMemberNode: 2023-02-28
+  dataone.autoRegisterMemberNode: 2023-02-28
 
   ## metacat.D1Client.CN_URL the url of the CN - DO NOT SET HERE
   ## D1Client.CN_URL: This is set in the global value 'global.d1ClientCnUrl', above
@@ -309,7 +307,7 @@ metacat:
   ## Node, in which case the field can be edited to set it to the value of a valid, existing Node
   ## Identifier.
   ##
-#  dataone.nodeId: urn:node:CHANGE_ME_TO_YOUR_VALUE!
+  dataone.nodeId: urn:node:METACAT_TEST
 
   ## @param metacat.dataone.subject The "subject" string from your DataONE MN client certificate
   ## The Node Subject is critical for proper operation of the node. To act as a Member Node in
@@ -326,12 +324,12 @@ metacat:
   ##       removed, and wrapped in double quotes, so it becomes:
   ##           dataone.subject: "CN=urn:node:YOUR_VALUE,DC=dataone,DC=org"
   ##
-#  dataone.subject: "CN=urn:node:CHANGE_ME_TO_YOUR_VALUE!,DC=dataone,DC=org"
+  dataone.subject: "CN=urn:node:METACAT1,DC=dataone,DC=org"
 
   ## @param metacat.dataone.nodeName short name for the node that can be used in user interfaces
   ## @param metacat.dataone.nodeDescription What is the node's intended scope and purpose?
-#  dataone.nodeName: My Metacat Node
-#  dataone.nodeDescription: Describe your Member Node briefly.
+  dataone.nodeName: My Metacat Node
+  dataone.nodeDescription: Describe your Member Node briefly.
 
   ## @param metacat.dataone.contactSubject registered contact for this MN
   ## IMPORTANT NOTE: Before registering you MN, you will need to first register your contact subject
@@ -341,7 +339,7 @@ metacat:
   ## an x509 client certificate, and use it as the value of dataone.contactSubject
   ## NOTE: you must use 'http://...' and NOT 'https://...' for this ORCID value:
   ##
-#  dataone.contactSubject: http://orcid.org/0000-0002-8888-999X
+  dataone.contactSubject: http://orcid.org/0000-0002-8888-999X
 
   ## @param metacat.dataone.nodeSynchronize Enable Synchronization of Metadata to DataONE
   ## Allows the administrator to decide whether to turn on synchronization with the DataONE
@@ -353,7 +351,7 @@ metacat:
   ## maintenance or service outages.
   ## (Default value shown - no need to uncomment unless changing from this)
   ##
-#  dataone.nodeSynchronize: false
+  dataone.nodeSynchronize: false
 
   ## metacat.dataone.nodeSynchronization.schedule: DataONE synchronization schedule (crontab format)
   ##
@@ -374,13 +372,13 @@ metacat:
   ## value like '15', which would change the schedule to synchronize at 11:15 am daily.
   ## (Default values shown - no need to uncomment unless changing from these)
   ##
-#  dataone.nodeSynchronization.schedule.year: "*"
-#  dataone.nodeSynchronization.schedule.mon: "*"
-#  dataone.nodeSynchronization.schedule.mday: "*"
-#  dataone.nodeSynchronization.schedule.wday: "?"
-#  dataone.nodeSynchronization.schedule.hour: "*"
-#  dataone.nodeSynchronization.schedule.min: "0/3"
-#  dataone.nodeSynchronization.schedule.sec: "10"
+  dataone.nodeSynchronization.schedule.year: "*"
+  dataone.nodeSynchronization.schedule.mon: "*"
+  dataone.nodeSynchronization.schedule.mday: "*"
+  dataone.nodeSynchronization.schedule.wday: "?"
+  dataone.nodeSynchronization.schedule.hour: "*"
+  dataone.nodeSynchronization.schedule.min: "0/3"
+  dataone.nodeSynchronization.schedule.sec: "10"
 
   ## @param metacat.dataone.nodeReplicate Accept and Store Replicas?
   ## Used to indicate that the administrator of this node is willing to allow replica data and
@@ -389,7 +387,7 @@ metacat:
   ## overall.
   ## (Default value shown - no need to uncomment unless changing from this)
   ##
-#  dataone.nodeReplicate: false
+  dataone.nodeReplicate: false
 
   ## @param metacat.dataone.replicationpolicy.default.numreplicas # copies to store on other nodes
   ## @param metacat.dataone.replicationpolicy.default.preferredNodeList Preferred replication nodes
@@ -408,9 +406,9 @@ metacat:
   ## values for both Default Preferred Nodes and Default Blocked Nodes is a comma-separated list
   ## of NodeReference identifiers that were assigned to the target nodes by DataONE.
   ##
-#  dataone.replicationpolicy.default.numreplicas: "0"
-#  dataone.replicationpolicy.default.preferredNodeList:
-#  dataone.replicationpolicy.default.blockedNodeList:
+  dataone.replicationpolicy.default.numreplicas: "0"
+  dataone.replicationpolicy.default.preferredNodeList: ""
+  dataone.replicationpolicy.default.blockedNodeList: ""
 
   ## @section OPTIONAL (but Recommended) Site Map Parameters
   ##
@@ -717,12 +715,19 @@ ingress:
   ## https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
   ##
   annotations:
-    ## @param ingress.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size - see docs:
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/client-body-buffer-size See docs:
     ## https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+    ##
     nginx.ingress.kubernetes.io/client-body-buffer-size: "1m"
-    ## @param ingress.annotations.nginx.ingress.kubernetes.io/client_max_body_size - see docs:
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/client_max_body_size See docs:
     ## https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    ## Setting size to 0 disables checking of client request body size
+    ##
     nginx.ingress.kubernetes.io/client_max_body_size: "0"
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/proxy-body-size See docs:
+    ## https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/configmap.md#proxy-body-size
+    ## Setting size to 0 disables checking of client request body size
+    ##
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
   ## @param ingress.defaultBackend.enabled enable the optional defaultBackend


### PR DESCRIPTION
While upgrading the dev cluster, we had to change `CSIDriver` settings from:


```yaml
spec:
  attachRequired: true
  fsGroupPolicy: ReadWriteOnceWithFSType
```

to:

```yaml
spec:
  attachRequired: false
  fsGroupPolicy: File
```

A side-effect of this is that k8s is now trying to recursively chang eownership/permissions on all the files every time it mounts a Volume, whether they need it or not. This takes a l-o-n-g time for large corpuses. I therefore set `fsGroupChangePolicy: OnRootMismatch` in values.yaml, to overcome this issue.

For reference:

> The `fsGroupPolicy: File` indicates that the CSI volume driver supports volume ownership and permission change via fsGroup, and Kubernetes may use fsGroup to change permissions and ownership of the volume to match user requested fsGroup in the pod's SecurityPolicy regardless of fstype or access mode.
> 
> ReadWriteOnceWithFSType: Indicates that volumes will be examined to determine if volume ownership and permissions should be modified to match the pod's security policy. Changes will only occur if the fsType is defined and the persistent volume's accessModes contain ReadWriteOnce.


