### PR TITLE
Add values to configure metacat ingress for a separate mcui instance

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -10,14 +10,14 @@ created by others. For more details, see https://github.com/NCEAS/metacat
 >    working well, but it has not yet been used in production - so we recommend caution with this
 >    early release. If you try it, [we'd love to hear your
 >    feedback](https://www.dataone.org/contact/)! After you have read the details below, [this
->    checklist](./helm/admin/MetacatQuickRef.md) may be helpful in guiding you through the necessary
+>    checklist](./admin/MetacatQuickRef.md) may be helpful in guiding you through the necessary
 >    installation steps.
 >
 >
 > 2. If you are considering **migrating an existing Metacat installation to Kubernetes**, note that
 >    ***before starting a migration, you must have a fully-functioning installation of Metacat
 >    version 2.19, running with PostgreSQL version 14. Migrating from other versions of Metacat
->    and/or PostgreSQL is not supported.*** See [this checklist](./helm/admin/MetacatQuickRef.md)
+>    and/or PostgreSQL is not supported.*** See [this checklist](./admin/MetacatQuickRef.md)
 >    for the necessary migration steps.
 >
 >

--- a/helm/README.md
+++ b/helm/README.md
@@ -295,19 +295,22 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 
 ### Global Properties Shared Across Sub-Charts Within This Deployment
 
-| Name                                 | Description                                                     | Value                             |
-| ------------------------------------ | --------------------------------------------------------------- | --------------------------------- |
-| `global.metacatExternalBaseUrl`      | Metacat base url accessible from outside cluster.               | `https://localhost/`              |
-| `global.d1ClientCnUrl`               | The url of the CN; used to populate metacat's 'D1Client.CN_URL' | `https://cn.dataone.org/cn`       |
-| `global.passwordsSecret`             | The name of the Secret containing application passwords         | `${RELEASE_NAME}-metacat-secrets` |
-| `global.metacatAppContext`           | The application context to use                                  | `metacat`                         |
-| `global.storageClass`                | default name of the storageClass to use for PVs                 | `local-path`                      |
-| `global.ephemeralVolumeStorageClass` | Optional global storageClass override                           | `""`                              |
-| `global.sharedVolumeSubPath`         | The subdirectory of the metacat data volume to mount            | `""`                              |
-| `global.dataone-indexer.enabled`     | Enable the dataone-indexer sub-chart                            | `true`                            |
-| `global.includeMetacatUi`            | Enable or disable the metacatui sub-chart.                      | `true`                            |
-| `global.metacatUiThemeName`          | The theme name to use. Required, even if overriding config.js   | `knb`                             |
-| `global.metacatUiWebRoot`            | The url root to be appended after the metacatui baseUrl.        | `/`                               |
+| Name                                                 | Description                                                                 | Value                             |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------- |
+| `global.metacatExternalBaseUrl`                      | Metacat base url accessible from outside cluster.                           | `https://localhost/`              |
+| `global.d1ClientCnUrl`                               | The url of the CN; used to populate metacat's 'D1Client.CN_URL'             | `https://cn.dataone.org/cn`       |
+| `global.passwordsSecret`                             | The name of the Secret containing application passwords                     | `${RELEASE_NAME}-metacat-secrets` |
+| `global.metacatAppContext`                           | The application context to use                                              | `metacat`                         |
+| `global.storageClass`                                | default name of the storageClass to use for PVs                             | `local-path`                      |
+| `global.ephemeralVolumeStorageClass`                 | Optional global storageClass override                                       | `""`                              |
+| `global.sharedVolumeSubPath`                         | The subdirectory of the metacat data volume to mount                        | `""`                              |
+| `global.dataone-indexer.enabled`                     | Enable the dataone-indexer sub-chart                                        | `true`                            |
+| `global.includeMetacatUi`                            | Enable or disable the MetacatUI sub-chart.                                  | `true`                            |
+| `global.metacatUiIngressBackend.enabled`             | Enable or disable MetacatUI support via Ingress                             | `false`                           |
+| `global.metacatUiIngressBackend.service.name`        | MetacatUI service name (used only if 'global.includeMetacatUi: false')      | `metacatui${RELEASE_NAME}`        |
+| `global.metacatUiIngressBackend.service.port.number` | Port for MetacatUI service (used only if 'global.includeMetacatUi: false')  | `80`                              |
+| `global.metacatUiThemeName`                          | MetacatUI theme name to use. (used only if 'global.includeMetacatUi: true') | `knb`                             |
+| `global.metacatUiWebRoot`                            | The url root to be appended after the MetacatUI baseUrl.                    | `/`                               |
 
 ### Metacat Application-Specific Properties
 
@@ -477,7 +480,7 @@ kubectl delete pvc -l release=my-release   ## DANGER! deletes all PVCs associate
 | `dataone-indexer.rabbitmq.extraConfiguration`                | extra config, to be appended to rmq config        | `consumer_timeout = 144000000`        |
 | `dataone-indexer.rabbitmq.auth.username`                     | set the username that rabbitmq will use           | `metacat-rmq-guest`                   |
 | `dataone-indexer.rabbitmq.auth.existingPasswordSecret`       | location of rabbitmq password                     | `${RELEASE_NAME}-metacat-secrets`     |
-| `dataone-indexer.solr.javaMem`                               | Java memory options to pass to the Solr container | `-Xms2g -Xmx2g`                       |
+| `dataone-indexer.solr.javaMem`                               | Java memory options to pass to the Solr container | `-Xms512m -Xmx2g`                     |
 | `dataone-indexer.solr.customCollection`                      | name of the solr collection to use                | `metacat-index`                       |
 | `dataone-indexer.solr.coreNames`                             | Solr core names to be created                     | `["metacat-core"]`                    |
 | `dataone-indexer.solr.persistence.size`                      | solr Persistent Volume size                       | `100Gi`                               |
@@ -530,8 +533,9 @@ properties](#global-properties-shared-across-sub-charts-within-this-deployment).
 can be found in the [MetacatUI README](https://github.com/NCEAS/metacatui/tree/develop/helm#readme).
 
 If you wish to disable the subchart altogether, set `global.includeMetacatUi: false` and provide
-your own MetacatUI installation. deployed separately.
-
+your own MetacatUI installation. deployed separately. Note that you can use the values in
+`global.metacatUiIngressBackend` to configure the ingress for your separate MetacatUI installation;
+see the documentation in [Values.yaml](./Values.yaml) for details.
 
 ## Persistence
 

--- a/helm/admin/MetacatQuickRef.md
+++ b/helm/admin/MetacatQuickRef.md
@@ -229,7 +229,8 @@ whether you are using the MetacatUI sub-chart or not:
 > IF MOVING DATA FROM AN EXISTING DEPLOYMENT THAT IS ALSO A DATAONE MEMBER NODE, DO NOT REGISTER
 > THIS NODE WITH THE PRODUCTION CN UNTIL YOU'RE READY TO GO LIVE, or bad things will happen...
 
-- [ ] Point the deployment at the **SANDBOX CN**
+- [ ] Point the deployment at the **SANDBOX CN** (and if you're not using the included MetacatUI
+      sub-chart, make sure your external MetacatUI instance is also pointing to the sandbox CN):
 
     ```yaml
     global:
@@ -445,7 +446,9 @@ whether you are using the MetacatUI sub-chart or not:
     global:
       d1ClientCnUrl: https://cn-sandbox.test.dataone.org/cn
     ```
-
+- [ ] If you're not using the included MetacatUI sub-chart, make sure your external MetacatUI
+      instance is also pointing to the production CN (delete `global.d1ClientCnUrl` in its values
+      overrides, since it defaults to production). In either case, ensure the MetacatUI pod restarts
 - [ ] ONLY if you changed any `dataone.*` member node properties (`dataone.nodeId`,
       `dataone.subject`, `dataone.nodeSynchronize`, `dataone.nodeReplicate`), push them to the CN by
       setting:

--- a/helm/admin/MetacatQuickRef.md
+++ b/helm/admin/MetacatQuickRef.md
@@ -163,39 +163,53 @@ file.**
       custom `metacat:` settings need to be transferred (e.g. `auth.allowedSubmitters:`, `guid.doi.username:`,
       `guid.doi.uritemplate.metadata:`, `guid.doi.doishoulder.1:`, etc.)
 
-* MetacatUI:
-  - [ ] ALWAYS set `global.metacatUiThemeName`
-  - [ ] If using a bundled theme (arctic, knb etc.):
-    - for PROD, no further action required
-    - for TEST, override at least `global.metacatExternalBaseUrl` and
-      `global.d1ClientCnUrl`
+### MetacatUI:
+Carefully review all Metacat's `global.metacatUi*` values and update as needed, depending upon
+whether you are using the MetacatUI sub-chart or not:
+- **For separately-deployed MetacatUI:**
+  - [ ] in the Metacat values overrides, set `global.includeMetacatUi: false` and override the
+    `global.metacatUiIngressBackend` settings subtree, and `global.metacatUiWebRoot`, if needed.
+    (`global.metacatUiThemeName` is not needed in Metacat values, for this type of deployment.)
+  - [ ] in the values overrides for the separate MetacatUI chart:
+    - Set `global.metacatUiThemeName` and `global.metacatExternalBaseUrl` (REQUIRED)
+    - Override `global.metacatAppContext` if needed (default is 'metacat')
+    - Override `global.metacatUiWebRoot` if needed (default is '/')
+    - Override `global.d1ClientCnUrl` to point at the sandbox CN
+      ("https://cn-sandbox.test.dataone.org/cn"), until final release (default is production CN)
 
-  - If using a theme from [metacatui-themes](https://github.com/NCEAS/metacatui-themes):
-    - [ ] it must be made available on a ceph/PV/PVC mount; e.g:
+- **If using a bundled theme (arctic, knb etc.):**
+  - for PROD, no further action required
+  - [ ] for TEST, override at least `global.metacatExternalBaseUrl` and `global.d1ClientCnUrl`
 
-        ```yaml
-        customTheme:
-          enabled: true
-          claimName: metacatsfwmd-metacatui-customtheme
-          subPath: metacatui-themes/src/cerp/js/themes/cerp
-        ```
+- **If using a theme from [metacatui-themes](https://github.com/NCEAS/metacatui-themes):**
+  - [ ] it must be made available on a ceph/PV/PVC mount; e.g:
 
-    - [ ] Ensure metacatui has read access
+      ```yaml
+      customTheme:
+        enabled: true
+        claimName: metacatsfwmd-metacatui-customtheme
+        subPath: metacatui-themes/src/cerp/js/themes/cerp
+      ```
 
-        ```shell
-        chmod -R o+rx metacatui
-        ```
-
-  - [ ] If the custom theme needs to be partially overridden by a separate config.js file (e.g.
-    `sfwmd.js` is used to override [the CERP
-    theme](https://github.com/NCEAS/metacatui-themes/tree/main/src/cerp/js/themes/cerp) above):
-
-    - [ ] set `metacatui.appConfig.enabled:` to `false`
-    - [ ] Create a configMap to replace `config.js`, as follows:
+  - [ ] Ensure metacatui has read access
 
       ```shell
-      kubectl create configmap metacatsfwmd-metacatui-config-js --from-file=config.js=sfwmd.js
+      chmod -R o+r .
+      find . -type d -print0 | xargs -0 chmod o+x
+      # set default ACLs so new files and directories from `git pull` will also be readable
+      sudo setfacl -R -d -m o:rx .
       ```
+
+- [ ] If the custom theme needs to be partially overridden by a separate config.js file (e.g.
+  `sfwmd.js` is used to override [the CERP
+  theme](https://github.com/NCEAS/metacatui-themes/tree/main/src/cerp/js/themes/cerp) above):
+
+  - [ ] set `metacatui.appConfig.enabled:` to `false`
+  - [ ] Create a configMap to replace `config.js`, as follows:
+
+    ```shell
+    kubectl create configmap metacatsfwmd-metacatui-config-js --from-file=config.js=sfwmd.js
+    ```
 
 
 ## 5F. `(FRESH INSTALL ONLY)` First Install

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -78,8 +78,8 @@ spec:
                 name: {{ $fullName }}-hl
                 port:
                   number: 8080
-          {{- if .Values.global.includeMetacatUi }}
           {{- $webroot := regexReplaceAll "/$" .Values.global.metacatUiWebRoot "" }}
+          {{- if .Values.global.includeMetacatUi }}
           - path: {{ $webroot }}/
             pathType: Prefix
             backend:
@@ -87,6 +87,13 @@ spec:
                 name: {{ .Release.Name }}-metacatui
                 port:
                   number: 80
+          {{- else }}
+            {{- if .Values.global.metacatUiIngressBackend.enabled }}
+          - path: {{ $webroot }}/
+            pathType: Prefix
+            backend:
+              {{- omit .Values.global.metacatUiIngressBackend "enabled" | toYaml | nindent 14 }}
+            {{- end }}
           {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,7 +36,7 @@ global:
 
   ## @param global.d1ClientCnUrl The url of the CN; used to populate metacat's 'D1Client.CN_URL'
   ## and the indexer sub-chart's 'D1Client.CN_URL'.
-  ## (Also parsed by the metacatui sub-chart to retrieve the CN base URL)
+  ## (Also parsed by the MetacatUI sub-chart to retrieve the CN base URL)
   ##
   d1ClientCnUrl: "https://cn.dataone.org/cn"
 
@@ -109,24 +109,24 @@ global:
   ##
   dataone-indexer.enabled: true
 
-  ## @param global.includeMetacatUi  Enable or disable the metacatui sub-chart.
-  ## Set to false if you want to connect to your own existing metacatui deployment.
+  ## @param global.includeMetacatUi  Enable or disable the MetacatUI sub-chart.
+  ## Set to false if you want to connect to your own existing MetacatUI deployment.
   ## See global.metacatUiIngressBackend (optional) if you wish to configure the ingress for your own
-  ## existing metacatui k8s deployment in the same namespace.
+  ## existing MetacatUI k8s deployment in the same namespace.
   ##
   includeMetacatUi: true
 
-  ## @param global.metacatUiIngressBackend (optional) ingress backend for external metacatui release
-  ## Added verbatim to the Ingress rules configuration, to allow metacat to work alongside a
-  ## metacatui instance deployed IN THE SAME NAMESPACE [note 1], via a separate helm chart (i.e. not
+  ## global.metacatUiIngressBackend - optional ingress backend for a non-subchart MetacatUI release.
+  ## Will be added verbatim to the Ingress rules configuration, to allow metacat to work alongside a
+  ## MetacatUI instance deployed IN THE SAME NAMESPACE [note 1], via a separate helm chart (i.e. not
   ## a subchart of this one).
-  ## NOTE: metacatUiIngressBackend will be IGNORED unless ALL the following conditions are met:
+  ## IMPORTANT: metacatUiIngressBackend will be IGNORED unless ALL the following conditions are met:
   ## 1. 'global.metacatUiIngressBackend.enabled' is set to 'true'
   ## 2. 'global.includeMetacatUi' is set to 'false' (i.e. MetacatUI is not deployed as a subchart)
   ## 3. 'ingress.enabled' is set to 'true'
   ## 4. 'ingress.rules' is empty [] (i.e. explicit ingress.rules will always take precedence)
   ##
-  ## NOTE 1: If you are deploying metacatui in a different namespace than metacat, then you can use
+  ## NOTE 1: If you are deploying MetacatUI in a different namespace than metacat, then you can use
   ##         an 'ExternalName' Service to act as a proxy. See:
   ##         https://stackoverflow.com/questions/59844622/ingress-configuration-for-k8s-in-different-namespaces
   ## NOTE 2: 'spec.rules.http.paths.path' will automatically be set to match any request with a
@@ -136,22 +136,22 @@ global:
   metacatUiIngressBackend:
     ## @param global.metacatUiIngressBackend.enabled Enable or disable MetacatUI support via Ingress
     ##
-    enabled: true
+    enabled: false
     service:
-      ## @param global.metacatUiIngressBackend.service.name Name of the metacatui service
-      ## This should be overridden with the name of the service created by the metacatui chart.
+      ## @param global.metacatUiIngressBackend.service.name MetacatUI service name (used only if 'global.includeMetacatUi: false')
+      ## This should be overridden with the name of the service created by the MetacatUI chart.
       ##
       name: metacatui${RELEASE_NAME}
       port:
-        ## @param global.metacatUiIngressBackend.service.port Port exposed by the metacatui service
+        ## @param global.metacatUiIngressBackend.service.port.number Port for MetacatUI service (used only if 'global.includeMetacatUi: false')
         ##
         number: 80
 
-  ## @param global.metacatUiThemeName The theme name to use. Required, even if overriding config.js
+  ## @param global.metacatUiThemeName MetacatUI theme name to use. (used only if 'global.includeMetacatUi: true')
   ##
   metacatUiThemeName: "knb"
 
-  ## @param global.metacatUiWebRoot The url root to be appended after the metacatui baseUrl.
+  ## @param global.metacatUiWebRoot The url root to be appended after the MetacatUI baseUrl.
   ## Starts with "/". Required, even if overriding config.js
   ##
   metacatUiWebRoot: "/"
@@ -767,7 +767,7 @@ ingress:
   ## ingress.defaultBackend (optional) default for any requests not matching defined paths
   ## @param ingress.defaultBackend.enabled enable the optional defaultBackend
   ## If none of the hosts or paths match the HTTP request in the Ingress objects, the traffic is
-  ## routed to your default backend. Not typically required, unless metacatui
+  ## routed to your default backend. Not typically required, unless MetacatUI
   ## Content included here under `defaultBackend` will be added to the ingress definition under
   ## 'spec.defaultBackend'; for example:
   ##

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -111,8 +111,41 @@ global:
 
   ## @param global.includeMetacatUi  Enable or disable the metacatui sub-chart.
   ## Set to false if you want to connect to your own existing metacatui deployment.
+  ## See global.metacatUiIngressBackend (optional) if you wish to configure the ingress for your own
+  ## existing metacatui k8s deployment in the same namespace.
   ##
   includeMetacatUi: true
+
+  ## @param global.metacatUiIngressBackend (optional) ingress backend for external metacatui release
+  ## Added verbatim to the Ingress rules configuration, to allow metacat to work alongside a
+  ## metacatui instance deployed IN THE SAME NAMESPACE [note 1], via a separate helm chart (i.e. not
+  ## a subchart of this one).
+  ## NOTE: metacatUiIngressBackend will be IGNORED unless ALL the following conditions are met:
+  ## 1. 'global.metacatUiIngressBackend.enabled' is set to 'true'
+  ## 2. 'global.includeMetacatUi' is set to 'false' (i.e. MetacatUI is not deployed as a subchart)
+  ## 3. 'ingress.enabled' is set to 'true'
+  ## 4. 'ingress.rules' is empty [] (i.e. explicit ingress.rules will always take precedence)
+  ##
+  ## NOTE 1: If you are deploying metacatui in a different namespace than metacat, then you can use
+  ##         an 'ExternalName' Service to act as a proxy. See:
+  ##         https://stackoverflow.com/questions/59844622/ingress-configuration-for-k8s-in-different-namespaces
+  ## NOTE 2: 'spec.rules.http.paths.path' will automatically be set to match any request with a
+  ##         prefix  matching whatever is set as 'global.metacatUiWebRoot', so don't forget to
+  ##         override that, if you want to use a different prefix than the default "/"
+  ##
+  metacatUiIngressBackend:
+    ## @param global.metacatUiIngressBackend.enabled Enable or disable MetacatUI support via Ingress
+    ##
+    enabled: true
+    service:
+      ## @param global.metacatUiIngressBackend.service.name Name of the metacatui service
+      ## This should be overridden with the name of the service created by the metacatui chart.
+      ##
+      name: metacatui${RELEASE_NAME}
+      port:
+        ## @param global.metacatUiIngressBackend.service.port Port exposed by the metacatui service
+        ##
+        number: 80
 
   ## @param global.metacatUiThemeName The theme name to use. Required, even if overriding config.js
   ##
@@ -736,7 +769,7 @@ ingress:
   ## If none of the hosts or paths match the HTTP request in the Ingress objects, the traffic is
   ## routed to your default backend. Not typically required, unless metacatui
   ## Content included here under `defaultBackend` will be added to the ingress definition under
-  ## `spec.defaultBackend'; for example:
+  ## 'spec.defaultBackend'; for example:
   ##
   ##   spec:
   ##     defaultBackend:
@@ -833,22 +866,23 @@ ingress:
 
   ## @param ingress.rules The Ingress rules can be defined here or left blank to be auto-populated
   ## based on the metacat.server.name value. If defining rules here, they will be copied verbatim
-  ## to the ingress definition. For schema guidance, see:
+  ## to the ingress definition, overriding any automatic configuration in the template. For schema
+  ## guidance, see:
   ## https://kubernetes.io/docs/concepts/services-networking/ingress/
   ## Example:
-  ##    - host: goa.nceas.ucsb.edu
+  ##    - host: knb.ecoinformatics.org
   ##      http:
   ##        paths:
   ##          - backend:
   ##              service:
-  ##                name: metacatgoa-hl
+  ##                name: metacatknb-hl
   ##                port:
   ##                  number: 8080
-  ##            path: /goa
+  ##            path: /knb
   ##            pathType: Prefix
   ##          - backend:
   ##              service:
-  ##                name: metacatgoa-metacatui
+  ##                name: metacatknb-metacatui
   ##                port:
   ##                  number: 80
   ##            path: /


### PR DESCRIPTION
add global values to enable metacat ingress to direct traffic to a separate mcui instance - see issue #2079