### PR TITLE
Metacat can't erase access/replication policies in the updateSystemMetadata method

### DIFF
--- a/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
+++ b/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
@@ -550,6 +550,9 @@ public class SystemMetadataManager {
                 }
                 this.insertReplicationPolicy(guid, policy, nodes, dbConn);
             }
+        } else {
+            // Delete the entire existing replication policies if it is null
+            deleteReplicationPolicy(guid, dbConn);
         }
 
         // save replica information
@@ -559,6 +562,29 @@ public class SystemMetadataManager {
         AccessPolicy accessPolicy = sm.getAccessPolicy();
         if (accessPolicy != null) {
             this.insertAccessPolicy(guid, accessPolicy, dbConn);
+        } else {
+            // Delete the entire existing access policies if it is null
+            deleteAccessPolicy(guid, dbConn);
+        }
+    }
+
+    private void deleteAccessPolicy(String guid, DBConnection dbCon) throws SQLException {
+        String delete = "DELETE FROM xml_access WHERE guid = ?";
+        try (PreparedStatement stmt = dbCon.prepareStatement(delete)) {
+            //data values
+            stmt.setString(1, guid);
+            //execute
+            stmt.executeUpdate();
+        }
+    }
+
+    private void deleteReplicationPolicy(String guid, DBConnection dbCon) throws SQLException {
+        String delete = "DELETE FROM smReplicationPolicy WHERE guid = ?";
+        try (PreparedStatement stmt = dbCon.prepareStatement(delete)) {
+            //data values
+            stmt.setString(1, guid);
+            //execute
+            stmt.executeUpdate();
         }
     }
 

--- a/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
+++ b/src/edu/ucsb/nceas/metacat/systemmetadata/SystemMetadataManager.java
@@ -569,6 +569,10 @@ public class SystemMetadataManager {
     }
 
     private void deleteAccessPolicy(String guid, DBConnection dbCon) throws SQLException {
+        if (guid == null || guid.isBlank()) {
+            logMetacat.warn("Metacat can't delete a null or blank pid from the xml_access table.");
+            return;
+        }
         String delete = "DELETE FROM xml_access WHERE guid = ?";
         try (PreparedStatement stmt = dbCon.prepareStatement(delete)) {
             //data values
@@ -579,6 +583,11 @@ public class SystemMetadataManager {
     }
 
     private void deleteReplicationPolicy(String guid, DBConnection dbCon) throws SQLException {
+        if (guid == null || guid.isBlank()) {
+            logMetacat.warn(
+                "Metacat can't delete a null or blank pid from the smReplicationPolicy table.");
+            return;
+        }
         String delete = "DELETE FROM smReplicationPolicy WHERE guid = ?";
         try (PreparedStatement stmt = dbCon.prepareStatement(delete)) {
             //data values

--- a/src/upgrade-db-to-3.3.0-postgres.sql
+++ b/src/upgrade-db-to-3.3.0-postgres.sql
@@ -1,0 +1,12 @@
+/*
+ * Add a new index on the smReplicationPolicy table
+ */
+CREATE INDEX IF NOT EXISTS smReplicationPolicy_guid on smReplicationPolicy(guid);
+
+/*
+ * update the database version
+ */
+UPDATE version_history SET status=0;
+
+INSERT INTO version_history (version, status, date_created)
+  VALUES ('3.3.0', 1, CURRENT_DATE);

--- a/src/xmltables-postgres.sql
+++ b/src/xmltables-postgres.sql
@@ -212,6 +212,7 @@ CREATE TABLE smReplicationPolicy (
   CONSTRAINT smReplicationPolicy_fk
     FOREIGN KEY (guid) REFERENCES systemMetadata DEFERRABLE
 );
+CREATE INDEX smReplicationPolicy_guid on smReplicationPolicy(guid);
 
 CREATE TABLE smReplicationStatus (
   guid text,  -- the globally unique string identifier of the object that the system metadata describes

--- a/test/edu/ucsb/nceas/metacat/dataone/MNodeServiceIT.java
+++ b/test/edu/ucsb/nceas/metacat/dataone/MNodeServiceIT.java
@@ -238,7 +238,7 @@ public class MNodeServiceIT {
         /**
          * Test to update replication policies
          * 1. Add a new preferred replication rule
-         * 2  Add a new blocked replication rule
+         * 2. Add a new blocked replication rule
          * 3. Set the replication policies to null
          * 4. Test to create an object with replication policies
          * @throws Exception


### PR DESCRIPTION
Please see details on this [ticket](https://github.com/NCEAS/metacat/issues/2206)