### PR TITLE
Fix startup crash when running in k8s

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,7 @@
 
 ## Release Notes for Metacat 3.4.0
 
-**Release date: 2026-05-06**
+**Release date: 2026-05-07**
 
 ### New Features & Enhancements:
 - Add support for partial object retrieval using HTTP byte ranges.
@@ -26,7 +26,7 @@
 
 ## Release Notes for helm chart 4.2.0
 
-**Release date: 2026-05-06**
+**Release date: 2026-05-07**
 
 This chart deploys the new Metacat 3.4.0 release. The Metacat app version update is the only change to the chart.
 

--- a/helm/config/log4j2.k8s.properties
+++ b/helm/config/log4j2.k8s.properties
@@ -3,8 +3,8 @@ name=Log4j2PropertiesConfigForMetacatK8s
 # Time period in seconds for reloading these settings
 monitorInterval=60
 
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.out
+appenders = consoleAppender
+loggers = dataone, replication, poolingHttpClientConnectionManager, apacheWire
 
 #############################################################
 # the appender named consoleAppender with the Console type #

--- a/helm/examples/values-dev-cluster-example.yaml
+++ b/helm/examples/values-dev-cluster-example.yaml
@@ -109,13 +109,15 @@ dataone-indexer:
     debug: false
 
   rabbitmq:
+    persistence:
+      storageClassName: "csi-cephfs-sc-ephemeral"
     resources:
       requests:
         cpu: 500m
         memory: 512Mi
       limits:
-        cpu: 1.0
-        memory: 1024Mi
+        cpu: "1"
+        memory: 1Gi
 
   solr:
     javaMem: "-XX:MaxRAMPercentage=75.0"


### PR DESCRIPTION
the k8s version of the log4j properties contained 2 outdated lines that were ignored by prior log4j versions, but which caused the latest version to crash on startup.

linking to #2294 