### PR TITLE
Exclude the non-existing members from package downloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
     <dependency>
         <groupId>org.dataone</groupId>
         <artifactId>speedbagit</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.0.4</version>
         <type>jar</type>
     </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
     <dependency>
         <groupId>org.dataone</groupId>
         <artifactId>speedbagit</artifactId>
-        <version>1.0.4</version>
+        <version>1.1.0-SNAPSHOT</version>
         <type>jar</type>
     </dependency>
         <dependency>

--- a/src/edu/ucsb/nceas/metacat/dataone/MNodeService.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/MNodeService.java
@@ -3054,8 +3054,8 @@ public class MNodeService extends D1NodeService
                     entrySysMeta = this.getSystemMetadata(session, entryPid);
                     objectInputStream = this.get(session, entryPid);
                 } catch (NotFound e) {
-                    logMetacat.warn("The data object " + entryPid.getValue() + " doesn't exist. "
-                                        + "So it will be excluded from the package downloading.");
+                    logMetacat.warn("The data object " + entryPid.getValue() + " doesn't exist, "
+                                        + "so it will be excluded from the dowload package.");
                     continue;
                 }
                 // Add the stream to the downloader, which will handle finding its location
@@ -3088,8 +3088,8 @@ public class MNodeService extends D1NodeService
                     } catch (NotFound e) {
                         logMetacat.warn(
                             "The scientific metadata object " + scienceMetadataIdentifier.getValue()
-                                + " doesn't exist. So it will be excluded from the package "
-                                + "downloading.");
+                                + " doesn't exist, so it will be excluded from the download "
+                                + "package.");
                         continue;
                     }
                     downloader.addScienceMetadata(systemMetadata, scienceMetadataStream);

--- a/src/edu/ucsb/nceas/metacat/dataone/MNodeService.java
+++ b/src/edu/ucsb/nceas/metacat/dataone/MNodeService.java
@@ -3048,9 +3048,18 @@ public class MNodeService extends D1NodeService
                     continue;
                 }
                 // Get the system metadata and a stream to the data file
-                SystemMetadata entrySysMeta = this.getSystemMetadata(session, entryPid);
-                InputStream objectInputStream = this.get(session, entryPid);
+                SystemMetadata entrySysMeta;
+                InputStream objectInputStream;
+                try {
+                    entrySysMeta = this.getSystemMetadata(session, entryPid);
+                    objectInputStream = this.get(session, entryPid);
+                } catch (NotFound e) {
+                    logMetacat.warn("The data object " + entryPid.getValue() + " doesn't exist. "
+                                        + "So it will be excluded from the package downloading.");
+                    continue;
+                }
                 // Add the stream to the downloader, which will handle finding its location
+                logMetacat.debug("Adding data to the bag " + entryPid.getValue());
                 downloader.addDataFile(entrySysMeta, objectInputStream);
                 try {
                     downloader.addSystemMetadata(entrySysMeta);
@@ -3064,19 +3073,25 @@ public class MNodeService extends D1NodeService
             try {
                 List<Identifier> scienceMetadataIdentifiers =
                     downloader.getScienceMetadataIdentifiers();
-                if (scienceMetadataIdentifiers != null && !scienceMetadataIdentifiers.isEmpty()) {
-                    Identifier sciMetataId = scienceMetadataIdentifiers.get(0);
-                    SystemMetadata systemMetadata = this.getSystemMetadata(session, sciMetataId);
-                    InputStream scienceMetadataStream = this.get(session, sciMetataId);
-                }
                 HashSet<Identifier> uniqueSciPids = new HashSet<>(scienceMetadataIdentifiers);
                 // Add the science metadata and their associated system metadatas to the downloader
                 for (Identifier scienceMetadataIdentifier : uniqueSciPids) {
-                    logMetacat.debug("Adding science metadata to the bag");
-                    SystemMetadata systemMetadata =
-                        this.getSystemMetadata(session, scienceMetadataIdentifier);
-                    InputStream scienceMetadataStream =
-                        this.get(session, scienceMetadataIdentifier);
+                    logMetacat.debug("Adding science metadata to the bag "
+                                         + scienceMetadataIdentifier.getValue());
+                    SystemMetadata systemMetadata;
+                    InputStream scienceMetadataStream;
+                    try {
+                        systemMetadata =
+                            this.getSystemMetadata(session, scienceMetadataIdentifier);
+                        scienceMetadataStream =
+                            this.get(session, scienceMetadataIdentifier);
+                    } catch (NotFound e) {
+                        logMetacat.warn(
+                            "The scientific metadata object " + scienceMetadataIdentifier.getValue()
+                                + " doesn't exist. So it will be excluded from the package "
+                                + "downloading.");
+                        continue;
+                    }
                     downloader.addScienceMetadata(systemMetadata, scienceMetadataStream);
                 }
 

--- a/src/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandler.java
+++ b/src/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandler.java
@@ -1534,7 +1534,7 @@ public class MNResourceHandler extends D1ResourceHandler {
             String errorMessage = "Couldn't get the package of " + pid + " since " + e.getMessage();
             logMetacat.error(errorMessage);
             // Error message will be sent as a zip file
-            fileNameRoot = "error-" + fileNameRoot;
+            fileNameRoot = "error_" + fileNameRoot;
             fileName = fileNameRoot + ".zip";
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             try (ZipOutputStream zos = new ZipOutputStream(baos)) {

--- a/src/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandler.java
+++ b/src/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandler.java
@@ -1,11 +1,14 @@
 package edu.ucsb.nceas.metacat.restservice.v2;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -16,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -1520,28 +1525,44 @@ public class MNResourceHandler extends D1ResourceHandler {
             formatId.setValue(format);
         }
         InputStream is = null;
+        //Use the pid as the file name prefix, replacing all non-word characters
+        String fileNameRoot = pid.replaceAll("\\W", "_");
+        String fileName = fileNameRoot + ".zip";
         try {
-            is = MNodeService.getInstance(request).getPackage(session, formatId , id);
-
-            //Use the pid as the file name prefix, replacing all non-word characters
-            String filename = pid.replaceAll("\\W", "_") + ".zip";
-
-            response.setHeader("Content-Disposition", ATTACHMENT + "; filename=\"" + filename+"\"");
-            response.setContentType("application/zip");
-            response.setStatus(200);
-            OutputStream out = response.getOutputStream();
-
-            // write it to the output stream
-            IOUtils.copyLarge(is, out);
-            IOUtils.closeQuietly(out);
-            long end = System.currentTimeMillis();
-            logMetacat.info(Settings.PERFORMANCELOG + pid
-                                    + Settings.PERFORMANCELOG_GET_PACKAGE_METHOD
-                                    + " Total getPackage method"
-                                    + Settings.PERFORMANCELOG_DURATION + (end-start)/1000);
-
+            is = MNodeService.getInstance(request).getPackage(session, formatId, id);
+        } catch (Exception e) {
+            String errorMessage = "Couldn't get the package of " + pid + " since " + e.getMessage();
+            logMetacat.error(errorMessage);
+            // Error message will be sent as a zip file
+            fileNameRoot = "error-" + fileNameRoot;
+            fileName = fileNameRoot + ".zip";
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                ZipEntry entry = new ZipEntry(fileNameRoot + ".txt");
+                zos.putNextEntry(entry);
+                zos.write(errorMessage.getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+            is = new ByteArrayInputStream(baos.toByteArray());
         } finally {
-            IOUtils.closeQuietly(is);
+            try {
+                response.setHeader(
+                    "Content-Disposition", ATTACHMENT + "; filename=\"" + fileName + "\"");
+                response.setContentType("application/zip");
+                response.setStatus(200);
+                try (OutputStream out = response.getOutputStream()) {
+                    // write it to the output stream
+                    IOUtils.copyLarge(is, out);
+                    out.flush();
+                }
+                long end = System.currentTimeMillis();
+                logMetacat.info(
+                    Settings.PERFORMANCELOG + pid + Settings.PERFORMANCELOG_GET_PACKAGE_METHOD
+                        + " Total getPackage method" + Settings.PERFORMANCELOG_DURATION
+                        + (end - start) / 1000);
+            } finally {
+                IOUtils.closeQuietly(is);
+            }
         }
    }
 

--- a/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerIT.java
+++ b/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerIT.java
@@ -1,16 +1,40 @@
 package edu.ucsb.nceas.metacat.restservice.v2;
 
+import edu.ucsb.nceas.metacat.dataone.D1NodeServiceTest;
 import edu.ucsb.nceas.metacat.util.SystemUtil;
 import org.apache.commons.io.IOUtils;
+import org.apache.wicket.protocol.http.mock.MockHttpServletRequest;
+import org.apache.wicket.protocol.http.mock.MockHttpServletResponse;
+import org.apache.wicket.protocol.http.mock.MockHttpSession;
 import org.dataone.client.rest.DefaultHttpMultipartRestClient;
+import org.dataone.client.v2.formats.ObjectFormatCache;
+import org.dataone.configuration.Settings;
 import org.dataone.mimemultipart.SimpleMultipartEntity;
+import org.dataone.ore.ResourceMapFactory;
+import org.dataone.service.types.v1.Identifier;
+import org.dataone.service.types.v1.Session;
+import org.dataone.service.types.v2.SystemMetadata;
+import org.dspace.foresite.ResourceMap;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,6 +59,16 @@ public class MNResourceHandlerIT extends MNResourceHandlerTest {
     private final static String qt_NOT_ALLOWED = "qt is not allowed";
     private final static String ENCODED_qt = "%71%74";
     private final static String SOLR_PATH = "/d1/mn/v2/query/solr";
+
+    private D1NodeServiceTest d1NodeTest = null;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        d1NodeTest = new D1NodeServiceTest("initialize");
+        Settings.getConfiguration().clearProperty("D1Client.CN_URL");
+        Settings.getConfiguration().addProperty("D1Client.CN_URL", "https://cn.dataone.org/cn");
+    }
 
 
     /**
@@ -132,6 +166,113 @@ public class MNResourceHandlerIT extends MNResourceHandlerTest {
         assertTrue(resultStr.contains(CHECKSUM));
         assertTrue(resultStr.contains(ENCODED_qt));
         assertFalse(resultStr.contains(SOLRCONFIG_PART_CONTENT));
+    }
+
+
+    /**
+     * Test the package API
+     */
+    @Test
+    public void testGetPackage() throws Exception {
+        // construct the ORE package
+        Identifier resourceMapId = new Identifier();
+        //resourceMapId.setValue("doi://1234/AA/map.1.1");
+        resourceMapId.setValue("testGetOREPackage-" + System.currentTimeMillis());
+        Identifier metadataId = new Identifier();
+        metadataId.setValue("doi://1234/AA/meta.1." + System.currentTimeMillis());
+        List<Identifier> dataIds = new ArrayList<>();
+        Identifier dataId = new Identifier();
+        dataId.setValue("doi://1234/AA/data.1." + System.currentTimeMillis());
+        Identifier dataId2 = new Identifier();
+        dataId2.setValue("doi://1234/AA/data.2." + System.currentTimeMillis());
+        dataIds.add(dataId);
+        dataIds.add(dataId2);
+        Map<Identifier, List<Identifier>> idMap = new HashMap<>();
+        idMap.put(metadataId, dataIds);
+        ResourceMapFactory rmf = ResourceMapFactory.getInstance();
+        ResourceMap resourceMap = rmf.createResourceMap(resourceMapId, idMap);
+        assertNotNull(resourceMap);
+        String rdfXml = ResourceMapFactory.getInstance().serializeResourceMap(resourceMap);
+        assertNotNull(rdfXml);
+
+        Session session = d1NodeTest.getTestSession();
+        InputStream object = null;
+        SystemMetadata sysmeta = null;
+
+        // save the data objects (data just contains their ID)
+        InputStream dataObject1 = new ByteArrayInputStream(dataId.getValue().getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(dataId, session.getSubject(), dataObject1);
+        dataObject1 = new ByteArrayInputStream(dataId.getValue().getBytes(StandardCharsets.UTF_8));
+        d1NodeTest.mnCreate(session, dataId, dataObject1, sysmeta);
+
+        // second data file
+        InputStream dataObject2 =
+            new ByteArrayInputStream(dataId2.getValue().getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(dataId2, session.getSubject(), dataObject2);
+        dataObject2 =
+            new ByteArrayInputStream(dataId2.getValue().getBytes(StandardCharsets.UTF_8));
+        d1NodeTest.mnCreate(session, dataId2, dataObject2, sysmeta);
+
+        // metadata file
+        InputStream metadataObject =
+            new ByteArrayInputStream(metadataId.getValue().getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(metadataId, session.getSubject(), metadataObject);
+        metadataObject =
+            new ByteArrayInputStream(metadataId.getValue().getBytes(StandardCharsets.UTF_8));
+        d1NodeTest.mnCreate(session, metadataId, metadataObject, sysmeta);
+
+        // save the ORE object
+        object = new ByteArrayInputStream(rdfXml.getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(resourceMapId, session.getSubject(), object);
+        sysmeta.setFormatId(
+            ObjectFormatCache
+                .getInstance().getFormat("http://www.openarchives.org/ore/terms")
+                .getFormatId());
+        object = new ByteArrayInputStream(rdfXml.getBytes(StandardCharsets.UTF_8));
+        Identifier pid =
+            d1NodeTest.mnCreate(session, resourceMapId, object, sysmeta);
+        request = Mockito.spy(new MockHttpServletRequest(
+            null,
+            new MockHttpSession(context),
+            context));
+        Mockito.doReturn("/packages/application%2Fbagit-1.0/" + resourceMapId.getValue())
+            .when(request)
+            .getPathInfo();
+        response = new MockHttpServletResponse(request);
+        resourceHandler = new MNResourceHandler(request, response);
+        resourceHandler.handle(GET);
+        Path bagFile = Files.createTempFile("bagit.", ".zip");
+        try {
+            byte[] bytes = response.getBinaryContent();
+            Files.write(bagFile, bytes);
+            // Check that the resource map is the same
+            ZipFile zipFile = new ZipFile(bagFile.toFile());
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                // Check if it's the ORE
+                if (entry.getName().contains("testGetOREPackage")) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    assertNotNull(stream2);
+                } else if (entry.getName().contains("metadata/science-metadata.xml")) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    metadataObject.reset();
+                    //assertTrue(IOUtils.contentEquals(stream2, metadataObject));
+                } else if (entry.getName().contains("data.1") && !(entry.getName()
+                    .contains("sysmeta"))) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    dataObject1.reset();
+                    assertTrue(IOUtils.contentEquals(stream2, dataObject1));
+                } else if (entry.getName().contains("data.2") && !(entry.getName()
+                    .contains("sysmeta"))) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    dataObject2.reset();
+                    assertTrue(IOUtils.contentEquals(stream2, dataObject2));
+                }
+            }
+        } finally {
+            Files.deleteIfExists(bagFile);
+        }
     }
 }
 

--- a/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerIT.java
+++ b/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerIT.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Vector;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -248,28 +249,133 @@ public class MNResourceHandlerIT extends MNResourceHandlerTest {
             // Check that the resource map is the same
             ZipFile zipFile = new ZipFile(bagFile.toFile());
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            Vector<String> list = new Vector<>();
+            list.add("resourceMap");
+            list.add("scienceMeta");
+            list.add("data1");
+            list.add("data2");
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
                 // Check if it's the ORE
                 if (entry.getName().contains("testGetOREPackage")) {
                     InputStream stream2 = zipFile.getInputStream(entry);
                     assertNotNull(stream2);
+                    list.remove("resourceMap");
                 } else if (entry.getName().contains("metadata/science-metadata.xml")) {
                     InputStream stream2 = zipFile.getInputStream(entry);
                     metadataObject.reset();
-                    //assertTrue(IOUtils.contentEquals(stream2, metadataObject));
+                    assertTrue(IOUtils.contentEquals(stream2, metadataObject));
+                    list.remove("scienceMeta");
                 } else if (entry.getName().contains("data.1") && !(entry.getName()
                     .contains("sysmeta"))) {
                     InputStream stream2 = zipFile.getInputStream(entry);
                     dataObject1.reset();
                     assertTrue(IOUtils.contentEquals(stream2, dataObject1));
+                    list.remove("data1");
                 } else if (entry.getName().contains("data.2") && !(entry.getName()
                     .contains("sysmeta"))) {
                     InputStream stream2 = zipFile.getInputStream(entry);
                     dataObject2.reset();
                     assertTrue(IOUtils.contentEquals(stream2, dataObject2));
+                    list.remove("data2");
                 }
             }
+            assertEquals(0, list.size());
+        } finally {
+            Files.deleteIfExists(bagFile);
+        }
+    }
+
+    /**
+     * Test the package API
+     */
+    @Test
+    public void testGetPackageWithMissingMember() throws Exception {
+        // construct the ORE package
+        Identifier resourceMapId = new Identifier();
+        //resourceMapId.setValue("doi://1234/AA/map.1.1");
+        resourceMapId.setValue("testGetOREPackage-" + System.currentTimeMillis());
+        Identifier metadataId = new Identifier();
+        metadataId.setValue("doi://1234/AA/meta.1." + System.currentTimeMillis());
+        List<Identifier> dataIds = new ArrayList<>();
+        Identifier dataId = new Identifier();
+        dataId.setValue("doi://1234/AA/data.1." + System.currentTimeMillis());
+        Identifier dataId2 = new Identifier();
+        dataId2.setValue("doi://1234/AA/data.2." + System.currentTimeMillis());
+        dataIds.add(dataId);
+        dataIds.add(dataId2);
+        Map<Identifier, List<Identifier>> idMap = new HashMap<>();
+        idMap.put(metadataId, dataIds);
+        ResourceMapFactory rmf = ResourceMapFactory.getInstance();
+        ResourceMap resourceMap = rmf.createResourceMap(resourceMapId, idMap);
+        assertNotNull(resourceMap);
+        String rdfXml = ResourceMapFactory.getInstance().serializeResourceMap(resourceMap);
+        assertNotNull(rdfXml);
+
+        Session session = d1NodeTest.getTestSession();
+        InputStream object = null;
+        SystemMetadata sysmeta = null;
+
+        // save the data objects (data just contains their ID)
+        InputStream dataObject1 = new ByteArrayInputStream(dataId.getValue().getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(dataId, session.getSubject(), dataObject1);
+        dataObject1 = new ByteArrayInputStream(dataId.getValue().getBytes(StandardCharsets.UTF_8));
+        d1NodeTest.mnCreate(session, dataId, dataObject1, sysmeta);
+
+        // No second data file created
+
+        // No metadata file created
+
+        // save the ORE object
+        object = new ByteArrayInputStream(rdfXml.getBytes(StandardCharsets.UTF_8));
+        sysmeta = D1NodeServiceTest.createSystemMetadata(resourceMapId, session.getSubject(), object);
+        sysmeta.setFormatId(
+            ObjectFormatCache
+                .getInstance().getFormat("http://www.openarchives.org/ore/terms")
+                .getFormatId());
+        object = new ByteArrayInputStream(rdfXml.getBytes(StandardCharsets.UTF_8));
+        Identifier pid =
+            d1NodeTest.mnCreate(session, resourceMapId, object, sysmeta);
+        request = Mockito.spy(new MockHttpServletRequest(
+            null,
+            new MockHttpSession(context),
+            context));
+        Mockito.doReturn("/packages/application%2Fbagit-1.0/" + resourceMapId.getValue())
+            .when(request)
+            .getPathInfo();
+        response = new MockHttpServletResponse(request);
+        resourceHandler = new MNResourceHandler(request, response);
+        resourceHandler.handle(GET);
+        Path bagFile = Files.createTempFile("bagit.", ".zip");
+        try {
+            Vector<String> list = new Vector<>();
+            list.add("resourceMap");
+            list.add("data1");
+            byte[] bytes = response.getBinaryContent();
+            Files.write(bagFile, bytes);
+            // Check that the resource map is the same
+            ZipFile zipFile = new ZipFile(bagFile.toFile());
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                // Check if it's the ORE
+                if (entry.getName().contains("testGetOREPackage")) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    assertNotNull(stream2);
+                    list.remove("resourceMap");
+                } else if (entry.getName().contains("metadata/science-metadata.xml")) {
+                   fail("The metadata object shouldn't be in the package");
+                } else if (entry.getName().contains("data.1") && !(entry.getName()
+                    .contains("sysmeta"))) {
+                    InputStream stream2 = zipFile.getInputStream(entry);
+                    dataObject1.reset();
+                    assertTrue(IOUtils.contentEquals(stream2, dataObject1));
+                    list.remove("data1");
+                } else if (entry.getName().contains("data.2")) {
+                    fail("The second data object shouldn't be in the package");
+                }
+            }
+            assertEquals(0, list.size());
         } finally {
             Files.deleteIfExists(bagFile);
         }

--- a/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerTest.java
+++ b/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerTest.java
@@ -538,8 +538,13 @@ public class MNResourceHandlerTest {
         Identifier guid = new Identifier();
         guid.setValue("testGetPackageFailed_" + System.currentTimeMillis());
         String error = "Not found " + guid.getValue();
-        request = new MockHttpServletRequest(null, new MockHttpSession(context), context);
-        request.setURL("packages/application%2Fbagit-1.0/" + guid.getValue());
+        request = Mockito.spy(new MockHttpServletRequest(
+                null,
+                new MockHttpSession(context),
+                context));
+        Mockito.doReturn("/packages/application%2Fbagit-1.0/" + guid.getValue())
+            .when(request)
+            .getPathInfo();
         response = new MockHttpServletResponse(request);
         try (MockedStatic<MNodeService> staticMock = Mockito.mockStatic(MNodeService.class)) {
             MNodeService mockMNodeService = Mockito.mock(MNodeService.class);
@@ -566,9 +571,7 @@ public class MNResourceHandlerTest {
                      new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
                 ZipEntry entry = zis.getNextEntry();
                 assertNotNull(entry);
-                assertTrue(entry.getName().startsWith("error_"));
-                assertTrue(entry.getName().contains(guid.getValue()));
-                assertTrue(entry.getName().endsWith(".txt"));
+                assertEquals("error_" + guid.getValue() + ".txt", entry.getName());
                 String content = IOUtils.toString(zis, StandardCharsets.UTF_8);
                 assertTrue(content.contains(guid.getValue()));
                 assertTrue(content.contains(error));

--- a/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerTest.java
+++ b/test/edu/ucsb/nceas/metacat/restservice/v2/MNResourceHandlerTest.java
@@ -2,6 +2,7 @@ package edu.ucsb.nceas.metacat.restservice.v2;
 
 import edu.ucsb.nceas.metacat.restservice.multipart.StreamingMultipartRequestResolver;
 import edu.ucsb.nceas.metacat.restservice.multipart.WrappingServletInputStream;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.HttpMultipartMode;
@@ -15,6 +16,7 @@ import org.apache.wicket.protocol.http.mock.MockServletContext;
 import org.dataone.client.v2.formats.ObjectFormatCache;
 import org.dataone.portal.PortalCertificateManager;
 import org.dataone.service.exceptions.NotAuthorized;
+import org.dataone.service.exceptions.NotFound;
 import org.dataone.service.types.v1.Identifier;
 import org.dataone.service.types.v1.Session;
 import org.dataone.service.types.v2.SystemMetadata;
@@ -37,6 +39,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Vector;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import edu.ucsb.nceas.LeanTestUtils;
 import edu.ucsb.nceas.metacat.dataone.MNodeService;
@@ -521,6 +525,55 @@ public class MNResourceHandlerTest {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any());
+            }
+        }
+    }
+
+    /**
+     * Test the scenario that the getPackage call throws an exception
+     * @throws Exception
+     */
+    @Test
+    public void testGetPackageFailed() throws Exception {
+        Identifier guid = new Identifier();
+        guid.setValue("testGetPackageFailed_" + System.currentTimeMillis());
+        String error = "Not found " + guid.getValue();
+        request = new MockHttpServletRequest(null, new MockHttpSession(context), context);
+        request.setURL("packages/application%2Fbagit-1.0/" + guid.getValue());
+        response = new MockHttpServletResponse(request);
+        try (MockedStatic<MNodeService> staticMock = Mockito.mockStatic(MNodeService.class)) {
+            MNodeService mockMNodeService = Mockito.mock(MNodeService.class);
+            // Prepare mock return values for the getPackage method
+            Mockito.when(mockMNodeService.getPackage(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            )).thenThrow(new NotFound("0000", error));
+            // static getInstance returns our mock
+            staticMock.when(() ->
+                                MNodeService.getInstance(Mockito.any())
+            ).thenAnswer(invocation -> {
+                return mockMNodeService;
+            });
+            // Entire object
+            response = new MockHttpServletResponse(request);
+            resourceHandler = new MNResourceHandler(request, response);
+            resourceHandler.handle(GET);
+            byte[] zipBytes = response.getBinaryContent();
+            assertNotNull(zipBytes);
+            assertTrue(zipBytes.length > 0);
+            try (ZipInputStream zis =
+                     new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+                ZipEntry entry = zis.getNextEntry();
+                assertNotNull(entry);
+                assertTrue(entry.getName().startsWith("error_"));
+                assertTrue(entry.getName().contains(guid.getValue()));
+                assertTrue(entry.getName().endsWith(".txt"));
+                String content = IOUtils.toString(zis, StandardCharsets.UTF_8);
+                assertTrue(content.contains(guid.getValue()));
+                assertTrue(content.contains(error));
+                // verify only one entry
+                assertNull(zis.getNextEntry());
             }
         }
     }


### PR DESCRIPTION
When users download a package, the non-existing member objects are excluded.

see #2263 