### PR TITLE
traefik ingress: move middleware chain annotation from conditional helper to ingress yaml

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -136,8 +136,6 @@ traefik.ingress.kubernetes.io annotations. Note these certificates are NOT the s
 used for TLS ("SSL") access via https
 */}}
 {{- define "dataone.traefik.mtls.annotations" -}}
-traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace -}}
-    -{{ .Release.Name }}-middleware-chain@kubernetescrd"
 traefik.ingress.kubernetes.io/router.tls.options: "{{ .Release.Namespace -}}
     -{{ .Release.Name }}-mtls-policy@kubernetescrd"
 {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -30,6 +30,8 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end -}}
     {{- if $isTraefik }}
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace -}}
+            -{{ .Release.Name }}-middleware-chain@kubernetescrd"
       {{- if $mutualAuth }}
         {{- include "dataone.traefik.mtls.annotations" . | nindent 4 }}
       {{- end }}


### PR DESCRIPTION
the middlewares chain would only be included in the ingress definition if  `metacat.dataone.certificate.fromHttpHeader.enabled` was `true`, which is erroneous - it should always be included for traefik ingresses. 