### PR TITLE
get catch-all default backend working for traefik

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -92,11 +92,13 @@ metadata:
       {{- include "dataone.nginx.mtls.snippets" . | nindent 6 }}
       {{- include "dataone.nginx.mtls.annotations" . | nindent 4 }}
     {{- end }}
-    {{- end }}
-spec:
   {{- if .Values.ingress.defaultBackend.enabled }}
+spec:
   defaultBackend:
-  {{- omit .Values.ingress.defaultBackend "enabled" | toYaml | nindent 4 }}
+    {{- omit .Values.ingress.defaultBackend "enabled" | toYaml | nindent 4 }}
+  {{- end }}
+  {{- else }}
+spec:
   {{- end }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}
@@ -127,22 +129,35 @@ spec:
                 name: {{ $fullName }}-hl
                 port:
                   number: 8080
-          {{- $webroot := regexReplaceAll "/$" .Values.global.metacatUiWebRoot "" }}
-          {{- if .Values.global.includeMetacatUi }}
-          - path: {{ $webroot }}/
+    {{/*  Remove trailing slash from .Values.global.metacatUiWebRoot, unless it is simply "/"  */}}
+    {{- $webroot := regexReplaceAll "/$" .Values.global.metacatUiWebRoot "" | trim | default "/" }}
+    {{- if and ( eq $webroot "/" ) (and $isTraefik .Values.ingress.defaultBackend.enabled) }}
+    {{- fail "Enable ingress.defaultBackend ONLY IF MetacatUI is NOT at the site root (\"/\")!" -}}
+    {{- end }}
+        {{- if .Values.global.includeMetacatUi }}
+          - path: {{ $webroot }}
             pathType: Prefix
             backend:
               service:
                 name: {{ .Release.Name }}-metacatui
                 port:
                   number: 80
-          {{- else }}
-            {{- if .Values.global.metacatUiIngressBackend.enabled }}
-          - path: {{ $webroot }}/
+        {{- else }}
+          {{- if .Values.global.metacatUiIngressBackend.enabled }}
+          - path: {{ $webroot }}
             pathType: Prefix
             backend:
               {{- omit .Values.global.metacatUiIngressBackend "enabled" | toYaml | nindent 14 }}
-            {{- end }}
           {{- end }}
+          {{- if and $isTraefik .Values.ingress.defaultBackend.enabled }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.defaultBackend.service.name }}
+                port:
+                  number: {{ .Values.ingress.defaultBackend.service.port.number }}
+          {{- end }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/middleware-chain.yaml
+++ b/helm/templates/middleware-chain.yaml
@@ -17,6 +17,10 @@ spec:
   chain:
     middlewares:
       - name: {{ $.Release.Name }}-security-headers
+
+    {{- if ne .Values.global.metacatUiWebRoot "/" }}
+      - name: {{ $.Release.Name }}-trailing-slash
+    {{- end }}
     {{- if .Values.ingress.ipAllowList }}
       - name: {{ $.Release.Name }}-ip-allowlist
     {{- end }}

--- a/helm/templates/middleware-redirects.yaml
+++ b/helm/templates/middleware-redirects.yaml
@@ -5,6 +5,22 @@
 ## IMPORTANT: ADD THE NAMES OF ANY NEW MIDDLEWARES TO helm/templates/middleware-chain.yaml, OR THEY
 ## WON'T BE LOADED!
 ##
+{{- if ne .Values.global.metacatUiWebRoot "/" }}
+---
+## Add trailing slash to metacatui webroot if not already existing
+##
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-trailing-slash
+  namespace: {{ .Release.Namespace }}
+spec:
+  redirectRegex:
+    regex: "^https?://([^/]+/{{- .Values.global.metacatUiWebRoot | trimPrefix "/" | trimSuffix "/" }})$"
+    replacement: "https://${1}/"
+    permanent: false
+
+{{- end }}
 ---
 ## Redirect robots.txt requests to the correct location on metacat.
 ##

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -710,22 +710,21 @@ ingress:
   annotations: {}
 
   ## @param ingress.defaultBackend.enabled Enable the optional defaultBackend
-  ## If none of the hosts or paths match the HTTP request in the Ingress objects, the traffic is
-  ## routed to your default backend. Not typically required, unless MetacatUI is not at the root
-  ## of the site (e.g. https://arcticdata.io/catalog)
-  ## Content included here under `defaultBackend` will be added to the ingress definition under
-  ## 'spec.defaultBackend'; for example:
-  ##
-  ##   spec:
-  ##     defaultBackend:
-  ##       enabled: true
-  ##       service:
-  ##         name: myrelease-wordpress
-  ##         port:
-  ##           number: 80
+  ## If none of the paths match the HTTP request in the Ingress objects, the traffic is routed
+  ## to your default backend.
+  ## IMPORTANT:
+  ## - Use this ONLY IF MetacatUI is NOT at the root of the site (e.g. for arcticdata.io, where
+  ##   MetacatUI is at: https://arcticdata.io/catalog)
+  ## - This creates a catch-all ingress path at the root of your site ("/") - so make sure that
+  ##   doesn't conflict with any other routes
+  ## - The content will be ignored if defaultBackend.enabled is set to false
   ##
   defaultBackend:
     enabled: false
+    service:
+      name: my-wordpress-service
+      port:
+        number: 80
 
   ## @param ingress.rewriteRules IMPORTANT! Nginx & Traefik rewrite rule syntaxes differ; see below
   ##


### PR DESCRIPTION
see #2337 

Adding support for `defaultBackend` to traefik ingress (traefik handles differently than nginx used to)